### PR TITLE
Adds php linting to TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ php:
   - '5.5'
   - '5.6'
 script: 
+  - 'find . -type f -iname "*.php" -not -path "./lib/quail/tests/*" -not -path "./vendor/*" | xargs -n1 php -l'
   - './vendor/phpunit/phpunit/phpunit --testsuite "UDOIT"'


### PR DESCRIPTION
The added command adds a test for TravisCI that will run all of the php files through the native php linter to make sure there's no syntax errors in files that aren't covered by unit tests yet.
