### PR TITLE
Solves #211

### DIFF
--- a/public/process.php
+++ b/public/process.php
@@ -166,7 +166,7 @@ switch ($main_action) {
 
             case 'tableThShouldHaveScope':
                 $new_content = filter_input(INPUT_POST, 'newcontent', FILTER_SANITIZE_STRING);
-                $corrected_error = $ufixit->fixTableThScopes($data['error_html'], $data['new_content']);
+                $corrected_error = $ufixit->fixTableThScopes($data['error_html'], $new_content);
                 break;
         }
 


### PR DESCRIPTION
The $ufixit->fixTableThScopes method was passing a non-existent key ('new_content') which I believe is a holdover from the last release. switching to $new_content (like all of the other ufixit options) solves this problem.