### PR TITLE
Udoit issue149 again

### DIFF
--- a/config/herokuConfig.php
+++ b/config/herokuConfig.php
@@ -14,7 +14,6 @@ $oauth2_uri       = getenv('OAUTH2_URI');
 /* Tool name for display in Canvas Navigation */
 $canvas_nav_item_name = getenv('CANVAS_NAV_ITEM_NAME');
 
-
 /* Database Config */
 
 $db_url           = parse_url(getenv('DATABASE_URL'));

--- a/config/herokuConfig.php
+++ b/config/herokuConfig.php
@@ -11,6 +11,10 @@ $oauth2_id        = getenv('OAUTH2_ID');
 $oauth2_key       = getenv('OAUTH2_KEY');
 $oauth2_uri       = getenv('OAUTH2_URI');
 
+/* Tool name for display in Canvas Navigation */
+$canvas_nav_item_name = getenv('CANVAS_NAV_ITEM_NAME');
+
+
 /* Database Config */
 
 $db_url           = parse_url(getenv('DATABASE_URL'));


### PR DESCRIPTION
During the initial merge to add this feature, I missed the one key file that actually enables this menu name to be output. Sorry to dirty the history to get this feature in. 

I've tested this on a Heroku deployment and it works as intended:
- 
![image](https://cloud.githubusercontent.com/assets/6798541/22250865/96726b64-e216-11e6-964a-5abcd273dcae.png)
- 
![image](https://cloud.githubusercontent.com/assets/6798541/22250873/a6affdde-e216-11e6-8682-626741d706e6.png)
 - 
![image](https://cloud.githubusercontent.com/assets/6798541/22250885/b7334a76-e216-11e6-82b7-fb5a54aca8d9.png)

Again, sorry for the trouble. 


