### PR TITLE
Fix contrast ratio issues with UDOIT Elements

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -59,7 +59,8 @@ body { padding: 20px 0 0; }
 	margin: 0;
 }
 
-.list-group-item .btn:hover{
+.list-group-item .viewError.btn:hover,
+.list-group-item .closeError.btn:hover{
 	background-color: #ccc;
 }
 
@@ -118,7 +119,7 @@ h3 a { color: inherit; }
 
 .content-title .proc-time{
 	font-size: 40%;
-	color: #aaaaaa;
+	color: #767676;
 	position: absolute;
 	bottom: 7px;
 	right: 0;
@@ -488,18 +489,18 @@ div#cached button.btn-success:hover{
 }
 
 .badge-error {
-  	background-color: #CA8A89;
+  	background-color: #A94442;
   	float: left !important;
   	margin-right: 6px;
   	font-size: 12px;
 }
 
 .panel-info .badge-error {
-	background-color: #4A94B9;
+	background-color: #31708f;
 }
 
 .panel-info .text-danger {
-	color: #4A94B9;
+	color: #0080a8;
 }
 
 .badge-suggestion {
@@ -616,6 +617,19 @@ ul.color-picker {
 	-webkit-text-stroke: .5px white;
 }
 
+/* Core bootstrap styles that don't meet WCAG2.0AA Requirements get overriden here */
+.label-danger {
+	background-color: #d4423c;
+}
+.btn-success {
+	background-color: #006800;
+	border-color: #106800;
+}
+.btn-success.active, .btn-success.focus,
+.btn-success:active, .btn-success:focus,
+.btn-success:hover, .open>.dropdown-toggle.btn-success {
+	background-color: #008a00;
+}
 /* X. FORMS --------------------------- */
 
 .fix-alt { position: relative; }


### PR DESCRIPTION
Several of the UDOIT elements do not meet the required contrast ratio
for WCAG2.0 (AA). The changes in this commit resolve all color contrast
issues as reported by the Chrome Developer Tool Accessibility audit
system
(https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en)

It also fixes what I imagine was a bug, where the "UDOIT" green buttons
were turning green on hover due to line 62 being too generic.

Solves #173 