### PR TITLE
Udoit issue168 - Add Unique ID to Form Elements

### DIFF
--- a/templates/partials/result_item/contrast.php
+++ b/templates/partials/result_item/contrast.php
@@ -26,12 +26,12 @@
 	<div class="left">
 		<div class="form-group no-margin margin-bottom">
 			<?php if ( isset($group_item->back_color) ): ?>
-				<label for="newcontent[1]">Replace Background Color <?= $group_item->back_color; ?></label>
-				<input class="color {hash:true,caps:false} form-control back-color" type="text" name="newcontent[1]" value="<?= $group_item->back_color; ?>" placeholder="Replacement for Background Color <?= $group_item->back_color; ?>">
+				<label for="<?= $this->e($item_id); ?>-bgcolor">Replace Background Color <?= $group_item->back_color; ?></label>
+				<input class="color {hash:true,caps:false} form-control back-color" type="text" name="newcontent[1]" value="<?= $group_item->back_color; ?>" placeholder="Replacement for Background Color <?= $group_item->back_color; ?>" id="<?= $this->e($item_id);-bgcolor?>">
 			<?php endif; ?>
 
-			<label for="newcontent[0]">Replace Foreground Color <?= $group_item->fore_color; ?></label>&nbsp;<span class="contrast-invalid hidden red"><span class="glyphicon glyphicon-remove"></span>&nbsp;Ratio Invalid (<span class="contrast-ratio"></span>:1)</span>
-			<input class="color {hash:true,caps:false} form-control fore-color" type="text" name="newcontent[0]" value="<?= $group_item->fore_color; ?>" placeholder="Replacement for Foreground Color <?= $group_item->fore_color; ?>">
+			<label for="<?= $this->e($item_id); ?>-fgcolor">Replace Foreground Color <?= $group_item->fore_color; ?></label>&nbsp;<span class="contrast-invalid hidden red"><span class="glyphicon glyphicon-remove"></span>&nbsp;Ratio Invalid (<span class="contrast-ratio"></span>:1)</span>
+			<input class="color {hash:true,caps:false} form-control fore-color" type="text" name="newcontent[0]" value="<?= $group_item->fore_color; ?>" placeholder="Replacement for Foreground Color <?= $group_item->fore_color; ?>" id="<?= $this->e($item_id); ?>-fgcolor">
 			<label><input name="add-bold" type="checkbox" value="bold" />&nbsp;Make this text bold</label>&nbsp;<label><input name="add-italic" type="checkbox" value="italic" />&nbsp;Make this text <span style="font-style: italics;">italicized</span></label><br />
 			<input type="text" name="threshold" class="threshold hidden" value="<?= $group_item->text_type; ?>">
 		</div>

--- a/templates/partials/result_item/contrast.php
+++ b/templates/partials/result_item/contrast.php
@@ -27,7 +27,7 @@
 		<div class="form-group no-margin margin-bottom">
 			<?php if ( isset($group_item->back_color) ): ?>
 				<label for="<?= $this->e($item_id); ?>-bgcolor">Replace Background Color <?= $group_item->back_color; ?></label>
-				<input class="color {hash:true,caps:false} form-control back-color" type="text" name="newcontent[1]" value="<?= $group_item->back_color; ?>" placeholder="Replacement for Background Color <?= $group_item->back_color; ?>" id="<?= $this->e($item_id);-bgcolor?>">
+				<input class="color {hash:true,caps:false} form-control back-color" type="text" name="newcontent[1]" value="<?= $group_item->back_color; ?>" placeholder="Replacement for Background Color <?= $group_item->back_color; ?>" id="<?= $this->e($item_id);?>-bgcolor">
 			<?php endif; ?>
 
 			<label for="<?= $this->e($item_id); ?>-fgcolor">Replace Foreground Color <?= $group_item->fore_color; ?></label>&nbsp;<span class="contrast-invalid hidden red"><span class="glyphicon glyphicon-remove"></span>&nbsp;Ratio Invalid (<span class="contrast-ratio"></span>:1)</span>

--- a/templates/partials/result_item/header_text.php
+++ b/templates/partials/result_item/header_text.php
@@ -19,7 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New heading text">
+	<label for="<?= $this->e($item_id); ?>">Enter New Text For This Heading</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New heading text" id="<?= $this->e($item_id); ?>">
 	<label><input class="remove-heading" type="checkbox" />&nbsp;Delete this Header completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/header_text.php
+++ b/templates/partials/result_item/header_text.php
@@ -19,7 +19,7 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<label for="<?= $this->e($item_id); ?>">Enter New Text For This Heading</label>
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text For This Heading</label>
 	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New heading text" id="<?= $this->e($item_id); ?>">
 	<label><input class="remove-heading" type="checkbox" />&nbsp;Delete this Header completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>

--- a/templates/partials/result_item/header_text.php
+++ b/templates/partials/result_item/header_text.php
@@ -19,8 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text For This Heading</label>
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New heading text" id="<?= $this->e($item_id); ?>">
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Enter New Text For This Heading</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New heading text" id="<?= $this->e($item_id); ?>-input">
 	<label><input class="remove-heading" type="checkbox" />&nbsp;Delete this Header completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/image_alt.php
+++ b/templates/partials/result_item/image_alt.php
@@ -19,9 +19,9 @@
 */
 ?>
 <div class="fix-alt input-group">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Provide New Alt Text For This Image</label>
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Provide New Alt Text For This Image</label>
 	<span class="counter">100</span>
-	<input class="form-control" type="text" name="newcontent" maxlength="100" placeholder="New alt text" id="<?= $this->e($item_id); ?>">
+	<input class="form-control" type="text" name="newcontent" maxlength="100" placeholder="New alt text" id="<?= $this->e($item_id); ?>-input">
 	<span class="input-group-btn">
 		<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 	</span>

--- a/templates/partials/result_item/image_alt.php
+++ b/templates/partials/result_item/image_alt.php
@@ -19,8 +19,9 @@
 */
 ?>
 <div class="fix-alt input-group">
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Provide New Alt Text For This Image</label>
 	<span class="counter">100</span>
-	<input class="form-control" type="text" name="newcontent" maxlength="100" placeholder="New alt text">
+	<input class="form-control" type="text" name="newcontent" maxlength="100" placeholder="New alt text" id="<?= $this->e($item_id); ?>">
 	<span class="input-group-btn">
 		<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 	</span>

--- a/templates/partials/result_item/link.php
+++ b/templates/partials/result_item/link.php
@@ -19,8 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text for This Link</label>
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>">
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Enter New Text for This Link</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>-input">
 	<label><input class="remove-link" type="checkbox" />Delete this Link completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/link.php
+++ b/templates/partials/result_item/link.php
@@ -19,7 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text">
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text for This Link</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>">
 	<label><input class="remove-link" type="checkbox" />Delete this Link completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/link_text.php
+++ b/templates/partials/result_item/link_text.php
@@ -19,7 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text">
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text for This Link</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>">
 	<label><input class="remove-link" type="checkbox" />&nbsp;Delete this Link completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/link_text.php
+++ b/templates/partials/result_item/link_text.php
@@ -19,8 +19,8 @@
 */
 ?>
 <div class="form-group no-margin margin-bottom">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter New Text for This Link</label>
-	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>">
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Enter New Text for This Link</label>
+	<input class="{hash:true,caps:false} form-control" type="text" name="newcontent" placeholder="New link text" id="<?= $this->e($item_id); ?>-input">
 	<label><input class="remove-link" type="checkbox" />&nbsp;Delete this Link completely instead</label><br />
 	<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 </div>

--- a/templates/partials/result_item/suspicious_link_text.php
+++ b/templates/partials/result_item/suspicious_link_text.php
@@ -19,7 +19,8 @@
 */
 ?>
 <div class="input-group">
-	<input class="form-control" type="text" name="newcontent" placeholder="New link description">
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter a New Description for This Link</label>
+	<input class="form-control" type="text" name="newcontent" placeholder="New link description" id="<?= $this->e($item_id); ?>">
 	<span class="input-group-btn">
 		<button class="submit-content inactive btn btn-default" type="submit">Submit</button>
 	</span>

--- a/templates/partials/result_item/suspicious_link_text.php
+++ b/templates/partials/result_item/suspicious_link_text.php
@@ -19,7 +19,7 @@
 */
 ?>
 <div class="input-group">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Enter a New Description for This Link</label>
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Enter a New Description for This Link</label>
 	<input class="form-control" type="text" name="newcontent" placeholder="New link description" id="<?= $this->e($item_id); ?>">
 	<span class="input-group-btn">
 		<button class="submit-content inactive btn btn-default" type="submit">Submit</button>

--- a/templates/partials/result_item/table_header.php
+++ b/templates/partials/result_item/table_header.php
@@ -20,8 +20,8 @@
 ?>
 <hr>
 <div class="input-group">
-	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Select which part of the table to convert to a header</label>
-	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
+	<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Select which part of the table to convert to a header</label>
+	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>-input">
 		<option value="row">The first row</option>
 		<option value="col">The first column</option>
 		<option value="both">Both the first row and column</option>

--- a/templates/partials/result_item/table_header.php
+++ b/templates/partials/result_item/table_header.php
@@ -19,8 +19,8 @@
 */
 ?>
 <hr>
-<label for="<?= $this->e($item_id); ?>">Select which part of the table to convert to a header</label>
 <div class="input-group">
+	<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Select which part of the table to convert to a header</label>
 	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
 		<option value="row">The first row</option>
 		<option value="col">The first column</option>

--- a/templates/partials/result_item/table_header.php
+++ b/templates/partials/result_item/table_header.php
@@ -21,7 +21,7 @@
 <hr>
 <p>Select which part of the table to convert to a header</p>
 <div class="input-group">
-	<select class="form-control" name="newcontent">
+	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
 		<option value="row">The first row</option>
 		<option value="col">The first column</option>
 		<option value="both">Both the first row and column</option>

--- a/templates/partials/result_item/table_header.php
+++ b/templates/partials/result_item/table_header.php
@@ -19,7 +19,7 @@
 */
 ?>
 <hr>
-<p>Select which part of the table to convert to a header</p>
+<label for="<?= $this->e($item_id); ?>">Select which part of the table to convert to a header</label>
 <div class="input-group">
 	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
 		<option value="row">The first row</option>

--- a/templates/partials/result_item/table_header_scope.php
+++ b/templates/partials/result_item/table_header_scope.php
@@ -18,8 +18,9 @@
 *	Primary Author Contact:  Jacob Bates <jacob.bates@ucf.edu>
 */
 ?>
+<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Select which part of the table to convert to a header</label>
 <div class="input-group">
-	<select class="form-control" name="newcontent">
+	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
 		<option value="col">col</option>
 		<option value="row">row</option>
 	</select>

--- a/templates/partials/result_item/table_header_scope.php
+++ b/templates/partials/result_item/table_header_scope.php
@@ -20,7 +20,7 @@
 ?>
 <label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Select which part of the table to convert to a header</label>
 <div class="input-group">
-	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
+	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>-input">
 		<option value="col">col</option>
 		<option value="row">row</option>
 	</select>

--- a/templates/partials/result_item/table_header_scope.php
+++ b/templates/partials/result_item/table_header_scope.php
@@ -18,7 +18,7 @@
 *	Primary Author Contact:  Jacob Bates <jacob.bates@ucf.edu>
 */
 ?>
-<label for="<?= $this->e($item_id); ?>" class="control-label sr-only">Select which part of the table to convert to a header</label>
+<label for="<?= $this->e($item_id); ?>-input" class="control-label sr-only">Select which part of the table to convert to a header</label>
 <div class="input-group">
 	<select class="form-control" name="newcontent" id="<?= $this->e($item_id); ?>">
 		<option value="col">col</option>

--- a/templates/partials/results_items.php
+++ b/templates/partials/results_items.php
@@ -145,7 +145,7 @@
 											}
 
 											if ( ! empty($result_template)) {
-												echo($this->fetch("partials/result_item/{$result_template}", ['group_item' => $group_item]));
+												echo($this->fetch("partials/result_item/{$result_template}", ['group_item' => $group_item, 'item_id' => $li_id]));
 											}
 										?>
 									</form>


### PR DESCRIPTION
This started off as me trying to resolve #168. Looking at the new templating system and the form elements that are output, it became clear that the missing label identified in #168 was indicative of a more widespread problem. Most of the form input fields we use during the UFIXIT phase are completely missing labels, or have a label element, but that label element does not actually link to the form input because those form inputs don't have unique ID's.

To resolve this, in https://github.com/cooperfellows/UDOIT/commit/5227a48a66614cf1d17bdc7105bbc40c71ebb2d7, I am now passing the unique id that is generated and placed on the `<li>` item (this is used to enable the expand/collapse of each item in the report).

Since we have a somewhat unique ID already, we are able to build on top of it with a simple modifier:
```php
id="<?= $this->e($item_id); ?>-input"
```
or for the color contrast system
```php
 id="<?= $this->e($item_id);?>-bgcolor"
```

Then a label is added that hooks up to those items:
```php
<label for="<?= $this->e($item_id); ?>-bgcolor">
```
or
```php
<label for="<?= $this->e($item_id); ?>-input"
```

I _believe_ this handles all the form inputs when reviewing proposed fixes. I identified these by using the [Chrome Developer Tools A11Y Audit](https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en).

There is still a good chunk of work to do to push this whole tool toward WCAG2.0 compliance. For instance, the expand and collapse functionality we have, not only for the sections (Page 1, Page 2, etc...), but also for the "View Issue Source", should be wired up with aria attributes to comply with the [spec for accordions](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion). That seemed like a lot of work to put into this PR, so I plan to create a new issue for that and submit fixes for that later.

I see two options moving forward on that front, build the aria labeling system into our existing templates, or switch our templates around to use an existing aria compliant accordion. [I've used one on some other projects](https://github.com/cooperfellows/a11y-accordion) with success. It is a relatively small library (8.33KB uncompressed, or 3.41KB minified), but it is another library. So I'm open to suggestions about the best way forward there.