### PR TITLE
Remove short open tags config no longer needed for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 -F phpfpm_custom.conf public/
+web: vendor/bin/heroku-php-apache2 public/

--- a/phpfpm_custom.conf
+++ b/phpfpm_custom.conf
@@ -1,1 +1,0 @@
-php_value[short_open_tag]=1


### PR DESCRIPTION
None of the code requires `short_open_tags` on, so let's simplify and remove it.

Fixes #286 