### PR TITLE
Changes report column name and adds migration script

### DIFF
--- a/HEROKU.md
+++ b/HEROKU.md
@@ -119,7 +119,7 @@ If you need to check that the tables exist, you can connect to Postgres using so
 * `Select * from users;` or `Select * from reports;` will show you their contents
 * `\q` quits the psql terminal
 
-If needed, you can manually run the table creation script: `Heroku run php lib/db_create_tables.php`
+If needed, you can manually run the table creation script: `heroku run composer dbsetup`
 
 ## Table Schema
-The table schema can be found in [lib/db_create_tables.php](lib/db_create_tables.php)
+The table schema can be found in [bin/db_create_tables.php](bin/db_create_tables.php)

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Edit `config/localConfig.php`:
 To create the required tables, run the creation script below.  You'll need to complete the db steps above first.
 
 ```
-$ php lib/db_create_tables.php
+$ php composer.phar dbsetup
 ```
 
-The table schema can be found in [lib/db_create_tables.php](lib/db_create_tables.php)
+The table schema can be found in [bin/db_create_tables.php](bin/db_create_tables.php)
 
 ## Configuration and Setup
 If you didn't already make `config/localConfig.php` when you set up the database, do it now.

--- a/app.json
+++ b/app.json
@@ -54,6 +54,6 @@
     }
   ],
   "scripts": {
-    "postdeploy": "php lib/db_create_tables.php"
+    "postdeploy": "composer dbsetup"
   }
 }

--- a/bin/db_create_tables.php
+++ b/bin/db_create_tables.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once(__DIR__.'/../config/settings.php');
-$dbh = include(__DIR__.'/db.php');
+$dbh = include(__DIR__.'/../lib/db.php');
 
 if ($db_type == 'pgsql'){
     // POSTGRESQL
@@ -10,7 +10,7 @@ if ($db_type == 'pgsql'){
           id SERIAL PRIMARY KEY,
           user_id integer,
           course_id integer,
-          file text,
+          report_json text,
           date_run timestamp with time zone,
           errors integer,
           suggestions integer
@@ -30,7 +30,7 @@ else{
           `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
           `user_id` int(10) unsigned NOT NULL,
           `course_id` int(10) unsigned NOT NULL,
-          `file` text NOT NULL,
+          `report_json` MEDIUMTEXT NOT NULL,
           `date_run` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
           `errors` int(10) unsigned NOT NULL,
           `suggestions` int(10) unsigned NOT NULL,

--- a/bin/move_reports_to_db.php
+++ b/bin/move_reports_to_db.php
@@ -1,0 +1,68 @@
+<?php
+/**
+*   Copyright (C) 2014 University of Central Florida, created by Jacob Bates, Eric Colon, Fenel Joseph, and Emily Sachs.
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*   Primary Author Contact:  Jacob Bates <jacob.bates@ucf.edu>
+*/
+
+require_once(__DIR__.'/../config/settings.php');
+$dbh = include(__DIR__.'/../lib/db.php');
+
+$rows = $dbh->query("SELECT * FROM {$db_reports_table}")->fetchAll();
+
+if( ! isset($rows[0]['file_path']))
+{
+	exit("It looks like this script doesnt need to be run");
+}
+
+if( ! isset($rows[0]['report_json']))
+{
+	// Quick hack to add report column since we dont have migrations yet
+	$column_type = $db_type == 'mysql' ? 'MEDIUMTEXT' : 'TEXT';
+	$dbh->query("ALTER TABLE {$db_reports_table} ADD report_json {$column_type}");
+}
+
+$sth = $dbh->prepare("UPDATE {$db_reports_table} set report_json = :report_json WHERE id = :id");
+$count_moved = 0;
+
+foreach ($rows as $row)
+{
+	if(empty($row['file_path'])) continue;
+
+	$file = __DIR__. '/'. $row['file_path'];
+	if( ! file_exists($file)){
+		echo("Json file not found {$file} for report id: {$row['id']}\n");
+		continue;
+	}
+
+	$json = file_get_contents($file);
+
+	if(empty($json)) continue;
+
+	$sth->bindValue(':report_json', $json, PDO::PARAM_STR);
+	$sth->bindValue(':id', $row['id'], PDO::PARAM_INT);
+	$res = $sth->execute();
+
+	if(!$res){
+		echo("Failed inserting report for {$row['id']}");
+		continue;
+	}
+
+	$count_moved++;
+}
+
+$dbh->query("ALTER TABLE {$db_reports_table} DROP COLUMN file_path");
+echo("Moved {$count_moved} reports from disk to the database. Feel free to delete the reports directory");

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,51 @@
     "keywords": ["instructure", "canvas", "education", "udoit", "ucf", "accessibility", "edtech", "canvas-lms", "instructure", "section-508"],
     "homepage": "https://github.com/ucfopen/UDOIT",
     "license": "GPL-3.0",
+    "scripts":{
+        "dbsetup" : "php bin/db_create_tables.php",
+        "migrate" : "php bin/move_reports_to_db.php"
+    },
+    "repositories"      : [
+        {
+            "type"    : "package",
+            "package" : {
+                "name"    : "EastDesire/jscolor",
+                "version" : "1.4.2",
+                "dist"    : {
+                    "url"  : "https://github.com/EastDesire/jscolor/archive/v1.4.2.zip",
+                    "type": "zip"
+                },
+                "source"  : {
+                    "url"       : "https://github.com/EastDesire/jscolor.git",
+                    "type"      : "git",
+                    "reference" : "tags/v1.4.2"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": "^5.4.0 || ^5.5.0 || ^5.6.0",
+        "ext-pdo": "*",
+        "ext-gd": "*",
+        "nategood/httpful": "^0.2.20",
+        "zaininnari/html-minifier": "^0.4.2",
+        "mpdf/mpdf": "^6.1.3",
+        "league/plates": "^3.1.1",
+        "monolog/monolog": "^1.21",
+        "mnsami/composer-custom-directory-installer": "1.1.*",
+        "EastDesire/jscolor":"1.4.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.8.*",
+        "phpspec/prophecy": "1.3.1",
+        "symfony/yaml": "v2.8.9",
+        "heroku/heroku-buildpack-php": "v117"
+    },
+    "extra": {
+        "installer-paths": {
+            "./public/assets/js/vendor/{$name}":["EastDesire/jscolor"]
+        }
+    },
     "authors": [
         {
             "name": "Jacob Bates",
@@ -62,46 +107,5 @@
             "homepage": "https://github.com/cooperfellows",
             "role": "Contributor"
         }
-    ],
-    "repositories"      : [
-        {
-            "type"    : "package",
-            "package" : {
-                "name"    : "EastDesire/jscolor",
-                "version" : "1.4.2",
-                "dist"    : {
-                    "url"  : "https://github.com/EastDesire/jscolor/archive/v1.4.2.zip",
-                    "type": "zip"
-                },
-                "source"  : {
-                    "url"       : "https://github.com/EastDesire/jscolor.git",
-                    "type"      : "git",
-                    "reference" : "tags/v1.4.2"
-                }
-            }
-        }
-    ],
-    "require": {
-        "php": "^5.4.0 || ^5.5.0 || ^5.6.0",
-        "ext-pdo": "*",
-        "ext-gd": "*",
-        "nategood/httpful": "^0.2.20",
-        "zaininnari/html-minifier": "^0.4.2",
-        "mpdf/mpdf": "^6.1.3",
-        "league/plates": "^3.1.1",
-        "monolog/monolog": "^1.21",
-        "mnsami/composer-custom-directory-installer": "1.1.*",
-        "EastDesire/jscolor":"1.4.2"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*",
-        "phpspec/prophecy": "1.3.1",
-        "symfony/yaml": "v2.8.9",
-        "heroku/heroku-buildpack-php": "v117"
-    },
-    "extra": {
-        "installer-paths": {
-            "./public/assets/js/vendor/{$name}":["EastDesire/jscolor"]
-        }
-    }
+    ]
 }

--- a/public/cached.php
+++ b/public/cached.php
@@ -22,7 +22,7 @@ require_once('../lib/utils.php');
 
 $dbh = include('../lib/db.php');
 // saves the report to the database
-$sth = $dbh->prepare(" SELECT * FROM {$db_reports_table} WHERE course_id = :courseid ORDER BY date_run DESC");
+$sth = $dbh->prepare(" SELECT id, date_run, errors, suggestions FROM {$db_reports_table} WHERE course_id = :courseid ORDER BY date_run DESC");
 
 session_start();
 

--- a/public/parseResults.php
+++ b/public/parseResults.php
@@ -53,18 +53,10 @@ if (isset($post_input['cached_id'])) {
 		}
 
 		$result = $sth->fetchAll(PDO::FETCH_ASSOC);
-		$json = $result[0]['file'];
-
-		if($json != null){
-			$udoit_report = json_decode($json);
-		} else {
-			$file = $result[0]['file_path'];
-			$json         = file_get_contents($file);
-			$udoit_report = json_decode($json);
-		}
+		$udoit_report = json_decode($result[0]['report_json']);
 	}
 
-	if (is_null($udoit_report)) {
+	if (empty($udoit_report)) {
 		$json_error = json_last_error_msg();
 		Utils::exitWithPartialError("Cannot parse this report. JSON error $json_error.");
 	}


### PR DESCRIPTION
## UPGRADE NOTE

When upgrading from a previous version of UDOIT, `php composer.phar migrate` will need to be run.  If it's not run - the result shouldn't be bad.  They'll have an extra column in the reports table, and the reports that aren't migrated from disk to the table just can't be viewed.

## Changes

* Scripts now added to composer.json
* Script for moving disk based reports into the db added
* Column name for reports.file changed to reports.report_json
* Column creation updated to use MEDIUMTEXT on mysql
* scripts moved in to bin directory
* contributors moved to bottom of composer.json
* report reading no longer attemps to read from disk

fixes: #296 