### PR TITLE
Dev/v2.3.1

### DIFF
--- a/config/localConfig.template.php
+++ b/config/localConfig.template.php
@@ -13,7 +13,7 @@ $oauth2_uri = ''; // EX: https://udoit.my-org.edu/oauth2response.php or https://
 $doc_length = '1500';
 
 /* Unscannable Suggestion */
-$unscannable_suggestion = 'Consider converting these documents to Pages, since they are easier to update and generally more accessible.';
+$unscannable_suggestion = 'Consider converting these documents to Pages, since they are easier to update, easier to view on mobile devices, and generally more accessible.';
 $unscannable_suggestion_on = true;
 
 /* Tool name for display in Canvas Navigation */

--- a/config/settings.php
+++ b/config/settings.php
@@ -32,7 +32,7 @@ ini_set("display_errors", ($UDOIT_ENV == ENV_PROD ? 0 : 1));
 isset($UDOIT_ENV) || $UDOIT_ENV = ENV_PROD; // !! override in your localConfig.php
 
 // SET UP OAUTH
-UdoitUtils::setupOauth($oauth2_id, $oauth2_key, $oauth2_id, $consumer_key, $shared_secret);
+UdoitUtils::setupOauth($oauth2_id, $oauth2_key, $oauth2_uri, $consumer_key, $shared_secret);
 
 // SET UP DATABASE
 UdoitDB::setup($db_type, $dsn, $db_user, $db_password);

--- a/config/settings.php
+++ b/config/settings.php
@@ -2,7 +2,7 @@
 define('ENV_TEST', 'test');
 define('ENV_PROD', 'prod');
 define('ENV_DEV', 'dev');
-define('UDOIT_VERSION', '2.3.0');
+define('UDOIT_VERSION', '2.3.1');
 
 // SET UP AUTOLOADER (uses autoload rules from composer)
 require_once(__DIR__.'/../vendor/autoload.php');

--- a/lib/UdoitJob.php
+++ b/lib/UdoitJob.php
@@ -167,9 +167,10 @@ class UdoitJob
 
     protected static function combineJobResults($job_group)
     {
+        global $logger;
         $totals = ['errors' => 0, 'warnings' => 0, 'suggestions' => 0];
-        $unscannables_items = [];
-        $content = [];
+        $unscannables_items = array();
+        $content = array();
 
         // combine the data from each job's results
         $sql = "SELECT * FROM job_queue WHERE job_group = '{$job_group}'";
@@ -182,12 +183,19 @@ class UdoitJob
             $totals['warnings']    += $results['total_results']['warnings'];
             $totals['suggestions'] += $results['total_results']['suggestions'];
 
+            // if the scan results array is empty for some reason,
+            // make sure it's an empty array and continue.
+            if (empty($results['scan_results'])) {
+                $results['scan_results'] = array();
+            }
+
             // if unscannables are found, collect them
             if (!empty($results['scan_results']['unscannable'])) {
                 $unscannables_items = array_merge($unscannables_items, $results['scan_results']['unscannable']);
                 unset($results['scan_results']['unscannable']);
             }
 
+            
             // merge the scan results
             $content = array_merge($content, $results['scan_results']);
         }

--- a/lib/quail/quail/common/accessibility_tests.php
+++ b/lib/quail/quail/common/accessibility_tests.php
@@ -5724,12 +5724,14 @@ class tableDataShouldHaveTh extends quailTableTest
 			foreach ($table->childNodes as $child) {
 				if ($this->propertyIsEqual($child, 'tagName', 'tbody') || $this->propertyIsEqual($child, 'tagName', 'thead')) {
 					foreach ($child->childNodes as $tr) {
-						foreach ($tr->childNodes as $th) {
-							if ($this->propertyIsEqual($th, 'tagName', 'th')) {
-								break 3;
-							} else {
-								$this->addReport($table);
-								break 3;
+						if (!is_null($tr->childNodes)) {
+							foreach ($tr->childNodes as $th) {
+								if ($this->propertyIsEqual($th, 'tagName', 'th')) {
+									break 3;
+								} else {
+									$this->addReport($table);
+									break 3;
+								}
 							}
 						}
 					}

--- a/migrations/000_db_create_tables.php
+++ b/migrations/000_db_create_tables.php
@@ -30,6 +30,7 @@ if ('sqlite' === $db_type || 'test' === $db_type) {
 
 if ('pgsql' === $db_type) {
     // POSTGRESQL
+    echo("Setting up tables in PostgreSQL\r\n");
     $tables = [
         '
             CREATE TABLE IF NOT EXISTS reports (
@@ -55,6 +56,7 @@ if ('pgsql' === $db_type) {
 
 if ('mysql' === $db_type) {
     // MYSQL
+    echo("Setting up tables in MySQL\r\n");
     $tables = [
         '
             CREATE TABLE IF NOT EXISTS `reports` (

--- a/migrations/001_move_reports_to_db.php
+++ b/migrations/001_move_reports_to_db.php
@@ -44,7 +44,7 @@ $check_for_column = function ($table, $columnName) {
 // if 'file_path' col is missing, there's nothing to do
 if (!$check_for_column($db_reports_table, 'file_path')) {
     if (!getenv('UNITTEST')) {
-        echo("It looks like this script doesnt need to be run");
+        echo("No need to migrate old reports, continuing...\r\n");
     }
 
     return;
@@ -53,6 +53,7 @@ if (!$check_for_column($db_reports_table, 'file_path')) {
 // add the column if it's missing
 if (!$check_for_column($db_reports_table, $col_to_add)) {
     // Quick hack to add report column since we dont have migrations yet
+    echo("Adding report_json column.\r\n");
     $column_type = $db_type == 'mysql' ? 'MEDIUMTEXT' : 'TEXT';
     UdoitDB::query("ALTER TABLE {$db_reports_table} ADD {$col_to_add} {$column_type}");
 }
@@ -60,11 +61,13 @@ if (!$check_for_column($db_reports_table, $col_to_add)) {
 // exit with warning if the column is still missing
 if (!check_for_column($dbh, $db_reports_table, $col_to_add)) {
     if (!getenv('UNITTEST')) {
-        echo("The migration script failed to create a ${col_to_add} column");
+        echo("The migration script failed to create a ${col_to_add} column\r\n");
     }
 
     return;
 }
+
+echo("Migrating old reports from disk to database.\r\n");
 
 // Grab all rows from the reports table
 if ($rows = UdoidDB::query('SELECT * FROM reports')) {
@@ -82,7 +85,7 @@ foreach ($rows as $row) {
 
     $file = __DIR__.'/'.$row['file_path'];
     if (!file_exists($file)) {
-        echo("Json file not found {$file} for report id: {$row['id']}\n");
+        echo("Json file not found {$file} for report id: {$row['id']}\r\n");
         continue;
     }
 
@@ -98,7 +101,7 @@ foreach ($rows as $row) {
 
     if (!$res) {
         print_r($sth->errorInfo());
-        echo("Failed inserting report for {$row['id']}\n");
+        echo("Failed inserting report for {$row['id']}\r\n");
         continue;
     }
 
@@ -106,4 +109,4 @@ foreach ($rows as $row) {
 }
 
 UdoitDB::query("ALTER TABLE {$db_reports_table} DROP COLUMN file_path");
-echo("Moved {$count_moved} reports from disk to the database. Feel free to delete the reports directory\n");
+echo("Moved {$count_moved} reports from disk to the database. Feel free to delete the reports directory\r\n");

--- a/migrations/001_move_reports_to_db.php
+++ b/migrations/001_move_reports_to_db.php
@@ -51,10 +51,10 @@ if (!$check_for_column($db_reports_table, 'file_path')) {
 }
 
 // add the column if it's missing
-if ($check_for_column($db_reports_table, $col_to_add)) {
+if (!$check_for_column($db_reports_table, $col_to_add)) {
     // Quick hack to add report column since we dont have migrations yet
     $column_type = $db_type == 'mysql' ? 'MEDIUMTEXT' : 'TEXT';
-    $dbh->query("ALTER TABLE {$db_reports_table} ADD {$col_to_add} {$column_type}");
+    UdoitDB::query("ALTER TABLE {$db_reports_table} ADD {$col_to_add} {$column_type}");
 }
 
 // exit with warning if the column is still missing
@@ -64,6 +64,11 @@ if (!check_for_column($dbh, $db_reports_table, $col_to_add)) {
     }
 
     return;
+}
+
+// Grab all rows from the reports table
+if ($rows = UdoidDB::query('SELECT * FROM reports')) {
+    $rows = $rows->fetchAll();
 }
 
 // now move the reports from the report files into the database

--- a/migrations/002_add_background_queue.php
+++ b/migrations/002_add_background_queue.php
@@ -24,6 +24,7 @@ if ('sqlite' === $db_type || 'test' === $db_type) {
 
 if ('pgsql' === $db_type) {
     // POSTGRESQL
+    echo("Creating job_queue in PostgreSQL\r\n");
     $queries = [
         '
             CREATE TABLE IF NOT EXISTS job_queue (
@@ -44,6 +45,7 @@ if ('pgsql' === $db_type) {
 
 if ('mysql' === $db_type) {
     // MYSQL
+    echo("Creating job_queue in MySQL\r\n");
     $queries = [
         '
             CREATE TABLE IF NOT EXISTS `job_queue` (

--- a/migrations/002_add_background_queue.php
+++ b/migrations/002_add_background_queue.php
@@ -52,7 +52,7 @@ if ('mysql' === $db_type) {
                 `user_id` int(10) unsigned NOT NULL,
                 `job_type` varchar(255) NOT NULL,
                 `data` text,
-                `results` text,
+                `results` mediumtext,
                 `status` varchar(255) NOT NULL DEFAULT "new",
                 `date_created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 `date_completed` timestamp,

--- a/migrations/003_add_refresh_token_to_users.php
+++ b/migrations/003_add_refresh_token_to_users.php
@@ -41,6 +41,7 @@ if ('sqlite' === $db_type || 'test' === $db_type) {
 
 if ('pgsql' === $db_type) {
     // POSTGRESQL
+    echo("Adding refresh_token and canvas_url fields in PostgreSQL\r\n");
     $queries = [
         [
             'isRequired' => !$check_for_column('users', 'refresh_token'),
@@ -55,6 +56,7 @@ if ('pgsql' === $db_type) {
 
 if ('mysql' === $db_type) {
     // MYSQL
+    echo("Adding refresh_token and canvas_url fields in MySQL\r\n");
     $queries = [
         [
             'isRequired' => !$check_for_column('users', 'refresh_token'),


### PR DESCRIPTION
- Fixed bug where $oauth2_id was sent in place of $oauth2_uri during the setupOauth call.
- Fixed bug where null or empty scan_results were not handled properly.
- Fixed bug where empty canvas_url fields in the user table were never updated with the proper value.
- Fixed bug where null values in table row child nodes were not handled properly.
- Fixed bug with migration scripts where the report_json column was never added to self-hosted instances.
- Added status messages to migration scripts to help with debugging in the future.
- Added mobile verbiage to the unscannable suggestion in localConfig.