### PR TITLE
Issue/561 youtube nocookie

### DIFF
--- a/lib/Udoit.php
+++ b/lib/Udoit.php
@@ -351,7 +351,7 @@ class Udoit
 
             case 'module_urls':
                 $url = "{$api_url}modules";
-                $search = '/(youtube|vimeo)/';
+                $search = '/(youtube|vimeo|youtu\.be|youtube\-nocookie)/';
                 $resp = static::apiGet($url, $api_key)->send()->body;
                 $count = 0;
 

--- a/lib/UdoitUtils.php
+++ b/lib/UdoitUtils.php
@@ -322,9 +322,10 @@ class UdoitUtils
         // If so, grab response object from session var aka 'cache'
         if (isset($_SESSION[$video_url]) && constant('USE_API_CACHING') != 'false') {
             $response = $_SESSION[$video_url];
-            $logger->addInfo("Cached api response used");
+            $logger->addInfo("Cached api response used for ".$video_url);
         } else {
             // Else, make api call and cache response in a session var
+            $logger->addInfo("Making fresh api call for ".$video_url);
             if (null == $api_key) {
                 $resp = Request::get($api_url)->send();
             } else {

--- a/lib/quail/quail/common/accessibility_tests.php
+++ b/lib/quail/quail/common/accessibility_tests.php
@@ -6450,7 +6450,7 @@ class videosEmbeddedOrLinkedNeedCaptions extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {
@@ -6501,7 +6501,7 @@ class videoCaptionsAreCorrectLanguage extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {
@@ -6554,7 +6554,7 @@ class videoUnlistedOrNotFound extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {

--- a/lib/quail/quail/common/accessibility_tests.php
+++ b/lib/quail/quail/common/accessibility_tests.php
@@ -6450,7 +6450,7 @@ class videosEmbeddedOrLinkedNeedCaptions extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube\-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {
@@ -6501,7 +6501,7 @@ class videoCaptionsAreCorrectLanguage extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube\-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {
@@ -6554,7 +6554,7 @@ class videoUnlistedOrNotFound extends quailTest
 	*/
 	function check()
 	{
-		$search_youtube = '/(youtube|youtu\.be|youtube-nocookie)/';
+		$search_youtube = '/(youtube|youtu\.be|youtube\-nocookie)/';
 		$search_vimeo = '/(vimeo)/';
 
 		foreach ($this->getAllElements(array('a', 'embed', 'iframe')) as $video) {

--- a/lib/quail/quail/common/services/media/vimeo.php
+++ b/lib/quail/quail/common/services/media/vimeo.php
@@ -130,12 +130,10 @@ class vimeoService extends mediaService
 	*/
 	private function isVimeoVideo($link_url)
 	{
-		global $logger;
 		$matches = null;
 		if( preg_match($this->regex, trim($link_url), $matches) === 1) {
 			return $matches[1];
 		}
-		$logger->addWarning('Non-Vimeo URL was filtered out of the Vimeo check. '.$link_url);
 		return false;
 	}
 }

--- a/lib/quail/quail/common/services/media/vimeo.php
+++ b/lib/quail/quail/common/services/media/vimeo.php
@@ -54,7 +54,7 @@ class vimeoService extends mediaService
 	}
 
 	/**
-	*	Checks to see if a video is missing caption information in YouTube
+	*	Checks to see if a video is missing caption information in Vimeo
 	*	@param string $link_url The URL to the video or video resource
 	*	@param string $course_locale The locale/language of the Canvas course
 	*	@return int 0 if captions are manual and wrong language, 1 if video is private, 2 if there are no captions or if manually generated and correct language

--- a/lib/quail/quail/common/services/media/vimeo.php
+++ b/lib/quail/quail/common/services/media/vimeo.php
@@ -130,10 +130,12 @@ class vimeoService extends mediaService
 	*/
 	private function isVimeoVideo($link_url)
 	{
+		global $logger;
 		$matches = null;
 		if( preg_match($this->regex, trim($link_url), $matches) === 1) {
 			return $matches[1];
 		}
+		$logger->addWarning('Non-Vimeo URL was filtered out of the Vimeo check. '.$link_url);
 		return false;
 	}
 }

--- a/lib/quail/quail/common/services/media/youtube.php
+++ b/lib/quail/quail/common/services/media/youtube.php
@@ -23,6 +23,7 @@ class youtubeService extends mediaService
 	    '@youtu\.be/v/([0-9a-zA-Z_-]+)@i',
 	    '@youtu\.be/watch\?v=([0-9a-zA-Z_-]+)@i',
 	    '@youtu\.be/\?v=([0-9a-zA-Z_-]+)@i',
+		'@youtube-nocookie\.com/embed/([0-9a-zA-Z_-]+)@i',
 		);
 
 	/**

--- a/lib/quail/quail/common/services/media/youtube.php
+++ b/lib/quail/quail/common/services/media/youtube.php
@@ -170,14 +170,12 @@ class youtubeService extends mediaService
 	*/
 	private function isYouTubeVideo($link_url)
 	{
-		global $logger;
 		$matches = null;
 		foreach($this->regex as $pattern) {
 			if( preg_match($pattern, trim($link_url), $matches) === 1) {
 				return $matches[1];
 			}
 		}
-		$logger->addWarning('Non-YouTube URL was filtered out of the YouTube check. '.$link_url);
 		return false;
 	}
 }

--- a/lib/quail/quail/common/services/media/youtube.php
+++ b/lib/quail/quail/common/services/media/youtube.php
@@ -23,7 +23,7 @@ class youtubeService extends mediaService
 	    '@youtu\.be/v/([0-9a-zA-Z_-]+)@i',
 	    '@youtu\.be/watch\?v=([0-9a-zA-Z_-]+)@i',
 	    '@youtu\.be/\?v=([0-9a-zA-Z_-]+)@i',
-		'@youtube-nocookie\.com/embed/([0-9a-zA-Z_-]+)@i',
+		'@youtube\-nocookie\.com/embed/([0-9a-zA-Z_-]+)@i',
 		);
 
 	/**

--- a/lib/quail/quail/common/services/media/youtube.php
+++ b/lib/quail/quail/common/services/media/youtube.php
@@ -170,12 +170,14 @@ class youtubeService extends mediaService
 	*/
 	private function isYouTubeVideo($link_url)
 	{
+		global $logger;
 		$matches = null;
 		foreach($this->regex as $pattern) {
 			if( preg_match($pattern, trim($link_url), $matches) === 1) {
 				return $matches[1];
 			}
 		}
+		$logger->addWarning('Non-YouTube URL was filtered out of the YouTube check. '.$link_url);
 		return false;
 	}
 }


### PR DESCRIPTION
Adds detection for youtube-nocookie videos.  I haven't had a successful test of it yet because I ran out of YouTube API quota.  Please test this and modify as necessary.  You can generate youtube-nocookie video embeds by using the built-in Youtube embedder in Canvas (it's in the toolbar of the Rich Content Editor).

Closes #561 