### PR TITLE
Issue/526 deprecate php

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To start the Heroku deployment process, you can click the button below, please n
 
 ## System Requirements
 * Apache or Nginx webserver
-* PHP 7.2, 7.3
+* PHP 7.3, 7.4
   * [GD Graphics Library](http://php.net/manual/en/book.image.php)
 * MySQL, MariaDB or PostgreSQL
 * Git (If you are using [The Git Method](#the-git-method) below) or if you plan on contributing to UDOIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   php:
     build:
       context: .
-      dockerfile: docker/php73-fpm.Dockerfile
+      dockerfile: docker/php74-fpm.Dockerfile
     volumes:
       - .:/var/www/html
 volumes:

--- a/docker/php74-fpm.Dockerfile
+++ b/docker/php74-fpm.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     libjpeg62-turbo-dev \
 	libpng-dev \
 	libpq-dev \
-	&& docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+	&& docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
 	&& docker-php-ext-install \
 	gd \
 	pdo \

--- a/lib/ims-blti/OAuth.php
+++ b/lib/ims-blti/OAuth.php
@@ -225,16 +225,8 @@ class OAuthRequest {
       $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
 
       $ourpost = $_POST;
-      // Deal with magic_quotes
-      // http://www.php.net/manual/en/security.magicquotes.disabling.php
-      if ( get_magic_quotes_gpc() ) {
-         $outpost = array();
-         foreach ($_POST as $k => $v) {
-            $v = stripslashes($v);
-            $ourpost[$k] = $v;
-         }
-      }
-     // Add POST Parameters if they exist
+
+      // Add POST Parameters if they exist
       $parameters = array_merge($parameters, $ourpost);
 
       // We have a Authorization-header with OAuth data. Parse the header
@@ -271,7 +263,7 @@ class OAuthRequest {
       $qparms = OAuthUtil::parse_parameters($parts['query']);
       $parameters = array_merge($qparms, $parameters);
     }
-     
+
 
     return new OAuthRequest($http_method, $http_url, $parameters);
   }


### PR DESCRIPTION
Deprecates PHP 7.1 and 7.2, as well as adds support for PHP 7.4.

Closes issue #526 
Closes issue #546 