### PR TITLE
Issue/93 Table head not detected

### DIFF
--- a/lib/quail/quail/common/accessibility_tests.php
+++ b/lib/quail/quail/common/accessibility_tests.php
@@ -5775,29 +5775,21 @@ class tableDataShouldHaveTh extends quailTableTest
 	function check()
 	{
 		foreach ($this->getAllElements('table') as $table) {
-			if (!($table->hasAttribute('role') && $table->getAttribute('role') == "presentation")){
+			if (!($table->hasAttribute('role') && $table->getAttribute('role') == "presentation")) {
 				foreach ($table->childNodes as $child) {
-					if ($this->propertyIsEqual($child, 'tagName', 'tbody') || $this->propertyIsEqual($child, 'tagName', 'thead')) {
-						foreach ($child->childNodes as $tr) {
-							foreach ($tr->childNodes as $th) {
-								if ($this->propertyIsEqual($th, 'tagName', 'th')) {
-									break 3;
-								} else {
-									$this->addReport($table);
-									break 3;
-								}
-							}
-						}
-					} elseif ($this->propertyIsEqual($child, 'tagName', 'tr')) {
-						foreach ($child->childNodes as $th) {
-							if ($this->propertyIsEqual($th, 'tagName', 'th')) {
-								break 2;
-							} else {
-								$this->addReport($table);
-								break 2;
-							}
-						}
-					}
+					// If $child is thead, tbody, or tr then we can evaluate
+					if (
+						$this->propertyIsEqual($child, 'tagName', 'thead') ||
+						$this->propertyIsEqual($child, 'tagName', 'tbody')
+					)
+						$trWrapper = $child;
+					elseif ($this->propertyIsEqual($child, 'tagName', 'tr'))
+						$trWrapper = $table;
+					else continue;
+
+					if (!$this->doRowsContainTH($trWrapper)) $this->addReport($table);
+
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Closes issue #93 .
Previous solution overwrote code for 'tableDataShouldHaveTh' which resulted in failure to detect th within rows. This request reintroduced the original version of the class, along with the check for role as presentation.