### PR TITLE
Incorrectly storing quiz ID instead of assignment ID

### DIFF
--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -618,9 +618,6 @@ class CanvasLms implements LmsInterface {
 
             case 'assignment':
                 $out['id'] = $lmsContent['id'];
-                if (!empty($lmsContent['quiz_id'])) {
-                    $out['id'] = $lmsContent['quiz_id'];
-                }
                 $out['title'] = $lmsContent['name'];
                 $out['updated'] = $lmsContent['updated_at'];
                 $out['body'] = $lmsContent['description'];


### PR DESCRIPTION
We're storing the quiz ID, but treating the content item like an assignment, which causes problems in UFIXIT. Let's just store the assignment ID instead.