### PR TITLE
Update api access for enforced scopes

### DIFF
--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -46,7 +46,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:GET|/api/v1/announcements
 * Assignments
     * url:GET|/api/v1/courses/:course_id/assignments
-    * url:get|/api/v1/courses/:course_id/assignments:id
+    * url:GET|/api/v1/courses/:course_id/assignments/:id
     * url:PUT|/api/v1/courses/:course_id/assignments/:id
 * Courses
     * url:GET|/api/v1/courses/:id

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -65,7 +65,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:GET|/api/v1/courses/:course_id/modules
     * url:GET|/api/v1/courses/:course_id/modules/:id
     * url:PUT|/api/v1/courses/:course_id/modules/:id
-    * url:GET|/api/v1/courses/:course_id/modules_id/items
+    * url:GET|/api/v1/courses/:course_id/modules/:module_id/items
     * url:GET|/api/v1/courses/:course_id/modules_id/items/:id
     * url:PUT|/api/v1/courses/:course_id/modules/:module_id/items/:id
 * Pages

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -51,7 +51,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
 * Courses
     * url:GET|/api/v1/courses/:id
     * url:PUT|/api/v1/courses/:id
-    * url:POST|/api/v1/courses_id/files
+    * url:POST|/api/v1/courses/:course_id/files
 * Discussion Topics
     * url:GET|/api/v1/courses/:course_id/discussion_topics
     * url:GET|/api/v1/courses/:course_id/discussion_topics/:topic_id

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -74,7 +74,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:GET|/api/v1/groups/:group_id/pages/:url
     * url:PUT|/api/v1/courses/:course_id/pages/:url
 * Quiz Questions
-    * ul:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions
+    * url:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions
     * url:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id
     * url:POST|/api/v1/courses/:course_id/quizzes/:quiz_id/questions u
     * url:PUT|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -66,7 +66,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:GET|/api/v1/courses/:course_id/modules/:id
     * url:PUT|/api/v1/courses/:course_id/modules/:id
     * url:GET|/api/v1/courses/:course_id/modules/:module_id/items
-    * url:GET|/api/v1/courses/:course_id/modules_id/items/:id
+    * url:GET|/api/v1/courses/:course_id/modules/:module_id/items/:id
     * url:PUT|/api/v1/courses/:course_id/modules/:module_id/items/:id
 * Pages
     * url:GET|/api/v1/courses/:course_id/pages

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -41,20 +41,49 @@ We strongly recommend you enforce scopes with your API key. The following scopes
 
 * Accounts
     * url:GET|/api/v1/accounts
-* Assignments
-    * url:GET|/api/v1/courses/:course_id/assignments
+    * url:GET|/api/v1/accounts/:id
 * Announcements
     * url:GET|/api/v1/announcements
+* Assignments
+    * url:GET|/api/v1/courses/:course_id/assignments
+    * url:get|/api/v1/courses/:course_id/assignments:id
+    * url:PUT|/api/v1/courses/:course_id/assignments:id
 * Courses
     * url:GET|/api/v1/courses/:id
+    * url:OUT|/api/v1/courses/:id
+    * url:POST|/api/v1/courses_id/files
 * Discussion Topics
     * url:GET|/api/v1/courses/:course_id/discussion_topics
+    * url:GET|/api/v1/courses/:course_id/discussion_topics/:topic_id
+    * url:PUT|/api/v1/courses/:course_id/discussion_topics/:topic_id
+* Enrollment Terms
+    * url:GETurl:GET|/api/v1/accounts/:account_id/terms|/api/v1/accounts/:account_id/terms
 * Files
     * url:GET|/api/v1/courses/:course_id/files
+    * url:GET|/api/v1/courses/:course_id/files/:id
 * Modules
     * url:GET|/api/v1/courses/:course_id/modules
+    * url:GET|/api/v1/courses/:course_id/modules/:id
+    * url:PUT|/api/v1/courses/:course_id/modules/:id
+    * url:GET|/api/v1/courses/:course_id/modules_id/items
+    * url:GET|/api/v1/courses/:course_id/modules_id/items/:id
+    * url:PUT|/api/v1/courses/:course_id/modules/:module_id/items/:id
 * Pages
     * url:GET|/api/v1/courses/:course_id/pages
+    * url:GET|/api/v1/courses/:course_id/pages/:url
+    * url:GET|/api/v1/groups/:group_id/pages/:url
+    * url:PUT|/api/v1/courses/:course_id/pages/:url
+* Quiz Questions
+    * ul:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions
+    * url:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id
+    * url:POST|/api/v1/courses/:course_id/quizzes/:quiz_id/questions u
+    * url:PUT|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id
+* Quizzes
+    * url:GET|/api/v1/courses/:course_id/quizzes
+    * url:GET|/api/v1/courses/:course_id/quizzes/:id
+    * url:PUT|/api/v1/courses/:course_id/quizzes/:id
+ * Users 
+    * url:GET|/api/v1/users/:id
 
 ---
 ## Create an LTI Developer Key

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -57,7 +57,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:GET|/api/v1/courses/:course_id/discussion_topics/:topic_id
     * url:PUT|/api/v1/courses/:course_id/discussion_topics/:topic_id
 * Enrollment Terms
-    * url:GETurl:GET|/api/v1/accounts/:account_id/terms|/api/v1/accounts/:account_id/terms
+    * url:GET|/api/v1/accounts/:account_id/terms
 * Files
     * url:GET|/api/v1/courses/:course_id/files
     * url:GET|/api/v1/courses/:course_id/files/:id

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -47,7 +47,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
 * Assignments
     * url:GET|/api/v1/courses/:course_id/assignments
     * url:get|/api/v1/courses/:course_id/assignments:id
-    * url:PUT|/api/v1/courses/:course_id/assignments:id
+    * url:PUT|/api/v1/courses/:course_id/assignments/:id
 * Courses
     * url:GET|/api/v1/courses/:id
     * url:OUT|/api/v1/courses/:id

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -76,7 +76,6 @@ We strongly recommend you enforce scopes with your API key. The following scopes
 * Quiz Questions
     * url:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions
     * url:GET|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id
-    * url:POST|/api/v1/courses/:course_id/quizzes/:quiz_id/questions u
     * url:PUT|/api/v1/courses/:course_id/quizzes/:quiz_id/questions/:id
 * Quizzes
     * url:GET|/api/v1/courses/:course_id/quizzes

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -50,7 +50,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
     * url:PUT|/api/v1/courses/:course_id/assignments/:id
 * Courses
     * url:GET|/api/v1/courses/:id
-    * url:OUT|/api/v1/courses/:id
+    * url:PUT|/api/v1/courses/:id
     * url:POST|/api/v1/courses_id/files
 * Discussion Topics
     * url:GET|/api/v1/courses/:course_id/discussion_topics

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -42,6 +42,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
 * Accounts
     * url:GET|/api/v1/accounts
     * url:GET|/api/v1/accounts/:id
+    * url:GET|/api/v1/accounts/:account_id/sub_accounts
 * Announcements
     * url:GET|/api/v1/announcements
 * Assignments


### PR DESCRIPTION
While trying to set this up I noticed that the listed scopes that where needed were not accurate. Luckily the error log showed which were being requested.

As a sidenote should I start with the main 3.x version or should I issue the currently listed as released 2.2.8 version if I am just starting?