### PR TITLE
disabling scan/save when issue is manually resolved

### DIFF
--- a/assets/js/Components/Forms/AltText.js
+++ b/assets/js/Components/Forms/AltText.js
@@ -168,7 +168,7 @@ export default class AltText extends React.Component {
             onChange={this.handleCheckbox} />
         </View>
         <View as="div" margin="small 0">
-          <Button color="primary" onClick={this.handleButton} interaction={(!pending) ? 'enabled' : 'disabled'}>
+          <Button color="primary" onClick={this.handleButton} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
             {('1' == pending) && <Spinner size="x-small" renderTitle={this.props.t(buttonLabel)} />}
             {this.props.t(buttonLabel)}
           </Button>

--- a/assets/js/Components/Forms/AnchorText.js
+++ b/assets/js/Components/Forms/AnchorText.js
@@ -98,7 +98,7 @@ export default class AnchorText extends React.Component {
           </View>
         </View>
         <View as="div" margin="small 0">
-          <Button color="primary" onClick={this.handleSubmit} interaction={(!pending) ? 'enabled' : 'disabled'}>
+          <Button color="primary" onClick={this.handleSubmit} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
             {('1' == pending) && <Spinner size="x-small" renderTitle={this.props.t(buttonLabel)} />}
             {this.props.t(buttonLabel)}
           </Button>

--- a/assets/js/Components/Forms/ContrastForm.js
+++ b/assets/js/Components/Forms/ContrastForm.js
@@ -278,7 +278,7 @@ export default class ContrastForm extends React.Component {
             </View>
 
             <View as="div" margin="medium 0">
-              <Button color="primary" onClick={this.handleSubmit} interaction={(!pending) ? 'enabled' : 'disabled'}>
+              <Button color="primary" onClick={this.handleSubmit} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
                 {('1' == pending) && <Spinner size="x-small" renderTitle={buttonLabel} />}
                 {this.props.t(buttonLabel)}
               </Button>

--- a/assets/js/Components/Forms/HeadingEmptyForm.js
+++ b/assets/js/Components/Forms/HeadingEmptyForm.js
@@ -135,7 +135,7 @@ export default class HeadingEmptyForm extends React.Component {
                     </View>
                 </View>
                 <View as="div" margin="small 0">
-                    <Button color="primary" onClick={this.handleSubmit} interaction={(!pending) ? 'enabled' : 'disabled'}>
+                    <Button color="primary" onClick={this.handleSubmit} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
                         {pending && <Spinner size="x-small" renderTitle={buttonLabel} />}
                         {this.props.t(buttonLabel)}
                     </Button>

--- a/assets/js/Components/Forms/HeadingStyleForm.js
+++ b/assets/js/Components/Forms/HeadingStyleForm.js
@@ -176,7 +176,7 @@ export default class HeadingStyleForm extends React.Component {
                         />
                 </View>
                 <View as="div" margin="small 0">
-                    <Button color="primary" onClick={this.handleSubmit} interaction={(!pending) ? 'enabled' : 'disabled'}>
+                    <Button color="primary" onClick={this.handleSubmit} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
                         {pending && <Spinner size="x-small" renderTitle={buttonLabel} />}
                         {this.props.t(buttonLabel)}
                     </Button>

--- a/assets/js/Components/Forms/TableHeaders.js
+++ b/assets/js/Components/Forms/TableHeaders.js
@@ -148,7 +148,7 @@ export default class TableHeaders extends React.Component {
         </View>
         
         <View as="div" margin="small 0">
-          <Button color="primary" onClick={this.handleSubmit} interaction={(!pending) ? 'enabled' : 'disabled'}>
+          <Button color="primary" onClick={this.handleSubmit} interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}>
               {('1' == pending) && <Spinner size="x-small" renderTitle={this.props.t(buttonLabel)} />}
               {this.props.t(buttonLabel)}
           </Button>

--- a/assets/js/Components/Forms/Video.js
+++ b/assets/js/Components/Forms/Video.js
@@ -30,7 +30,7 @@ export default class Video extends React.Component {
         <Button
           color="primary"
           onClick={this.handleVideoRescan}
-          interaction={!pending ? 'enabled' : 'disabled'}
+          interaction={(!pending && this.props.activeIssue.status !== 2) ? 'enabled' : 'disabled'}
         >
           {'1' == pending && (
             <Spinner size="x-small" renderTitle={buttonLabel} />


### PR DESCRIPTION
When an issue is marked as manually resolved, the scan and save buttons should be disabled. 