### PR TITLE
disabling next/prev/close buttons when form is processing

### DIFF
--- a/assets/js/Components/UfixitModal.js
+++ b/assets/js/Components/UfixitModal.js
@@ -86,6 +86,8 @@ class UfixitModal extends React.Component {
     const ufixitService = new Ufixit()
     const { activeIssue, activeContentItem } = this.props
 
+    const pending = (this.props.activeIssue && (this.props.activeIssue.pending == '1'))
+
     let activeIndex = this.findActiveIndex();
     const UfixitForm = ufixitService.returnIssueForm(activeIssue)
 
@@ -237,11 +239,13 @@ class UfixitModal extends React.Component {
                   </InlineList>
                 </Flex.Item>
                 <Flex.Item>
-                  <Button margin="0 small" onClick={this.props.handleCloseButton}>{this.props.t('label.close')}</Button>
-                  <Button margin="0 0 0 x-small"
-                    onClick={() => this.handleIssueChange(activeIndex - 1)}>{this.props.t('label.previous_issue')}</Button>
-                  <Button color="primary" margin="0 0 0 x-small"
-                    onClick={() => this.handleIssueChange(activeIndex + 1)}>{this.props.t('label.next_issue')}</Button>
+                  <Button margin="0 small" interaction={(!pending) ? 'enabled' : 'disabled'} onClick={this.props.handleCloseButton}>{this.props.t('label.close')}</Button>
+                  <Button margin="0 0 0 x-small" interaction={(!pending) ? 'enabled' : 'disabled'} onClick={() => this.handleIssueChange(activeIndex - 1)}>
+                    {this.props.t('label.previous_issue')}
+                  </Button>
+                  <Button margin="0 0 0 x-small" interaction={(!pending) ? 'enabled' : 'disabled'} onClick={() => this.handleIssueChange(activeIndex + 1)}>
+                    {this.props.t('label.next_issue')}
+                  </Button>
                 </Flex.Item>
               </Flex>            
             </View>


### PR DESCRIPTION
When an issue is processing, the next, previous, and close buttons should be disabled. We are in the process of finishing up some functionality that will rescan content after an issue is submitted so disabling the buttons will avoid any issues with that. 