### PR TITLE
updating alt text form to still check for data-decorative 

### DIFF
--- a/assets/js/Components/Forms/AltText.js
+++ b/assets/js/Components/Forms/AltText.js
@@ -129,14 +129,15 @@ export default class AltText extends React.Component {
   }
 
   elementIsDecorative(htmlString) {
-    const decorativeAttribute = Html.getAttribute(htmlString, "role")
+    const decorativeAttribute = Html.getAttribute(htmlString, "data-decorative")
+    const roleAttribute = Html.getAttribute(htmlString, "role")
     const classes = Html.getClasses(htmlString)
 
     if (Html.getTagName(htmlString) !== 'IMG') {
       return false
     }
 
-    return (decorativeAttribute === 'presentation' || (classes.includes('phpally-ignore')))
+    return (decorativeAttribute === 'true' || roleAttribute === 'presentation' || (classes.includes('phpally-ignore')))
   }
 
   render() {


### PR DESCRIPTION
Since older content may still have the "data-decorative=true" attribute, the alt text form still needs to check for that when determining if something is marked as decorative. 