### PR TITLE
Issue/652 welcome page

### DIFF
--- a/assets/js/Components/AboutPage.js
+++ b/assets/js/Components/AboutPage.js
@@ -88,7 +88,7 @@ class AboutPage extends React.Component {
                 <View as="div" margin="small large" key={issueType}>
                   <View padding="x-small" margin="none">
                     <Heading level="h3">
-                      {('error' === issueType) ? <IconNoLine className={Classes.error} /> : <IconInfoBorderlessLine className={Classes.suggestion} />}
+                      {('error' === issueType) ? <IconNoLine className={Classes.error} /> : <IconInfoBorderlessLine className={Classes.suggestion} />}&nbsp;
                       {this.props.t(`label.plural.${issueType}`)}
                     </Heading><br />
                   </View>

--- a/assets/js/Components/AboutPage.js
+++ b/assets/js/Components/AboutPage.js
@@ -86,8 +86,12 @@ class AboutPage extends React.Component {
               const type = this.issues[issueType]
               return (
                 <View as="div" margin="small large" key={issueType}>
-                  {('error' === issueType) ? <IconNoLine className={Classes.error} /> : <IconInfoBorderlessLine className={Classes.suggestion} />}
-                  <View padding="x-small"><Text weight="bold">{this.props.t(`label.plural.${issueType}`)}</Text><br /></View>
+                  <View padding="x-small">
+                    <Heading  margin="none" padding="small" level="h3">
+                      {('error' === issueType) ? <IconNoLine className={Classes.error} /> : <IconInfoBorderlessLine className={Classes.suggestion} />}
+                      {this.props.t(`label.plural.${issueType}`)}
+                    </Heading><br />
+                  </View>
                   {type.map((rule) => {
                     if (!this.props.t(`rule.example.${rule}`).includes('rule.example')) {
                       var showExample = true
@@ -95,7 +99,6 @@ class AboutPage extends React.Component {
                     return (
                       <ToggleDetails key={rule} summary={this.props.t(`rule.label.${rule}`)}>
                         <View as="div" margin="small 0" background="primary" padding="small" shadow="above">
-                          <Heading level="h4">{this.props.t(`rule.label.${rule}`)}</Heading>
                           {ReactHtmlParser(this.props.t(`rule.desc.${rule}`), { preprocessNodes: (nodes) => Html.processStaticHtml(nodes, this.props.settings) })}
                           {
                             (showExample) &&

--- a/assets/js/Components/AboutPage.js
+++ b/assets/js/Components/AboutPage.js
@@ -86,8 +86,8 @@ class AboutPage extends React.Component {
               const type = this.issues[issueType]
               return (
                 <View as="div" margin="small large" key={issueType}>
-                  <View padding="x-small">
-                    <Heading  margin="none" padding="small" level="h3">
+                  <View padding="x-small" margin="none">
+                    <Heading level="h3">
                       {('error' === issueType) ? <IconNoLine className={Classes.error} /> : <IconInfoBorderlessLine className={Classes.suggestion} />}
                       {this.props.t(`label.plural.${issueType}`)}
                     </Heading><br />
@@ -97,7 +97,11 @@ class AboutPage extends React.Component {
                       var showExample = true
                     }
                     return (
-                      <ToggleDetails key={rule} summary={this.props.t(`rule.label.${rule}`)}>
+                      <ToggleDetails key={rule} summary={
+                        <Heading level="h4">
+                          {this.props.t(`rule.label.${rule}`)}
+                        </Heading>}
+                      >
                         <View as="div" margin="small 0" background="primary" padding="small" shadow="above">
                           {ReactHtmlParser(this.props.t(`rule.desc.${rule}`), { preprocessNodes: (nodes) => Html.processStaticHtml(nodes, this.props.settings) })}
                           {

--- a/assets/js/Components/Header.js
+++ b/assets/js/Components/Header.js
@@ -11,7 +11,7 @@ import { AppNav } from '@instructure/ui-navigation'
 import Api from '../Services/Api'
 
 class Header extends React.Component {
-  
+
   constructor(props) {
     super(props);
 
@@ -32,7 +32,7 @@ class Header extends React.Component {
           margin="none"
           renderBeforeItems={
             <View as="h1" margin="0" padding="0 medium 0 0">
-              <img className={`${Classes.logo}`} alt="UDOIT logo" src={Logo}></img>
+              <img className={`${Classes.logo}`} alt="UDOIT" src={Logo}></img>
             </View>
           }
           visibleItemsCount={3}
@@ -46,7 +46,7 @@ class Header extends React.Component {
               {/* <Menu.Item onClick={() => this.handleMoreNav('settings')}>{this.props.t('menu.settings')}</Menu.Item> */}
               <Menu.Separator />
               <Menu.Item onClick={this.props.handleCourseRescan}>{this.props.t('menu.scan_course')}</Menu.Item>
-              <Menu.Separator />  
+              <Menu.Separator />
               <Menu.Item href={pdfUrl}>{this.props.t('menu.download_pdf')}</Menu.Item>
             </Menu>
           }


### PR DESCRIPTION
Closes #652 

- Changes the alt text for the h1 image from "UDOIT logo" to "UDOIT"
- Turns Errors/Suggestions into h3s
- Removes redundant issue names, turning the toggles into h4s.

Feedback appreciated.
