### PR TITLE
Make the LTI JWKS exchange more general for all LMSes

### DIFF
--- a/src/Controller/LtiController.php
+++ b/src/Controller/LtiController.php
@@ -101,7 +101,11 @@ class LtiController extends AbstractController
 
         if (isset($token->{'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'})) {
             $redirectUrl = $token->{'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'} . '?auth_token=' . $this->session->getUuid();
-            return $this->redirect($redirectUrl);
+
+            // Avoid a never-ending redirect loop
+            if (strpos($redirectUrl, $this->request->getRequestUri()) === false) {
+                return $this->redirect($redirectUrl);
+            }
         }
 
         return $this->redirectToRoute('dashboard',
@@ -239,6 +243,14 @@ class LtiController extends AbstractController
                 }
             }
 
+            // Context is optional and contains a unique id, label, title, and type
+            if (!empty($token->{'https://purl.imsglobal.org/spec/lti/claim/context'})) {
+                $contextFields = (array) $token->{'https://purl.imsglobal.org/spec/lti/claim/context'};
+                foreach ($contextFields as $key => $val) {
+                    $this->session->set('lms_course_' . $key, $val);
+                }
+            }
+
             $roles = [];
             if (!empty($token->{'https://purl.imsglobal.org/spec/lti/claim/roles'})) {
                 $roleFields = (array) $token->{'https://purl.imsglobal.org/spec/lti/claim/roles'};
@@ -249,8 +261,26 @@ class LtiController extends AbstractController
             }
             $this->session->set('roles', array_values(array_unique($roles)));
 
-            if (isset($token->name)) {
+            // Full display name including titles and suffixes displayed according to user locale/pref
+            if (!empty($token->name)) {
                 $this->session->set('lms_user_name', $token->name);
+            }
+
+            if (!empty($token->given_name)) {
+                $this->session->set('lms_user_given_name', $token->given_name);
+            }
+
+            if (!empty($token->family_name)) {
+                $this->session->set('lms_user_family_name', $token->family_name);
+            }
+
+            if (!empty($token->email)) {
+                $this->session->set('lms_user_email', $token->email);
+            }
+
+            // Required except for anonymous launches; this is stable over time and may not be display friendly
+            if (!empty($token->sub)) {
+                $this->session->set('lms_user_id', $token->sub);
             }
 
             $lms->saveTokenToSession($token);

--- a/src/Lms/D2l/D2lLms.php
+++ b/src/Lms/D2l/D2lLms.php
@@ -149,11 +149,6 @@ class D2lLms implements LmsInterface {
     {
         $session = $this->sessionService->getSession();
 
-        $contextFields = (array) $token->{'https://purl.imsglobal.org/spec/lti/claim/context'};
-        foreach ($contextFields as $key => $val) {
-            $session->set('lms_course_' . $key, $val);
-        }
-
         $brightspaceFields = (array) $token->{'http://www.brightspace.com'};
         foreach ($brightspaceFields as $key => $val) {
             $session->set('lms_' . $key, $val);


### PR DESCRIPTION
The current LTI exchange is very Canvas-specific. 

The LTI spec (http://www.imsglobal.org/spec/lti/v1p3/#tool-deployment) details:

* sub: required user identity info
* given_name: optional
* family_name: optional
* email: optional
* context: optional contains info about where tool launched from 