### PR TITLE
Redirect logs to stderr

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -8,7 +8,7 @@ monolog:
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
         nested:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            path: "php://stderr"
             level: debug
         console:
             type: console


### PR DESCRIPTION
This should make actually viewing logs in Docker and Heroku possible.