### PR TITLE
Issue/753 fix deprecation warnings

### DIFF
--- a/src/Entity/ContentItem.php
+++ b/src/Entity/ContentItem.php
@@ -88,9 +88,9 @@ class ContentItem implements \JsonSerializable
 
     /**
      * Serializes ContentItem into JSON.
-     * @return array|mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -90,9 +90,9 @@ class Course implements \JsonSerializable
 
     /**
      * Serializes Course with basic information needed by front-end.
-     * @return array|mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             "id" => $this->id,

--- a/src/Entity/FileItem.php
+++ b/src/Entity/FileItem.php
@@ -237,9 +237,9 @@ class FileItem implements \JsonSerializable
 
     /**
      * Serializes ContentItem into JSON.
-     * @return array|mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Entity/Institution.php
+++ b/src/Entity/Institution.php
@@ -319,7 +319,7 @@ class Institution implements JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->id,

--- a/src/Entity/Issue.php
+++ b/src/Entity/Issue.php
@@ -87,9 +87,9 @@ class Issue implements \JsonSerializable
 
     /**
      * Serializes Issue into JSON.
-     * @return array|mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             "id" => $this->id,

--- a/src/Entity/LogEntry.php
+++ b/src/Entity/LogEntry.php
@@ -126,7 +126,7 @@ class LogEntry implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'message' => $this->getMessage(),

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -83,14 +83,14 @@ class Report implements \JsonSerializable
     // Public Methods
     /**
      *
-     * @return array|mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
 
-    public function toArray() 
+    public function toArray(): array
     {
         $result = [
             "id" => $this->id,

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -13,7 +13,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
  * @ORM\Table(name="users")
  */
-class User implements UserInterface, \Serializable, JsonSerializable
+class User implements UserInterface, JsonSerializable
 {
     /**
      * @ORM\Id()
@@ -225,24 +225,18 @@ class User implements UserInterface, \Serializable, JsonSerializable
         return $this;
     }
 
-    /** @see \Serializable::serialize() */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(array(
+        return [
             $this->id,
             $this->username,
             $this->lmsUserId
-        ));
+        ];
     }
 
-    /** @see \Serializable::unserialize() */
-    public function unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        list(
-            $this->id,
-            $this->username,
-            $this->lmsUserId
-        ) = unserialize($serialized);
+        [$this->id, $this->username, $this->lmsUserId] = $data;
     }
 
     public function jsonSerialize(): array

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -245,7 +245,7 @@ class User implements UserInterface, \Serializable, JsonSerializable
         ) = unserialize($serialized);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $dateFormat = $_ENV['DATE_FORMAT'];
         $apiKey = $this->getApiKey();

--- a/src/Entity/UserSession.php
+++ b/src/Entity/UserSession.php
@@ -91,7 +91,7 @@ class UserSession implements JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getUuid(),

--- a/src/Lms/LmsResponse.php
+++ b/src/Lms/LmsResponse.php
@@ -91,7 +91,7 @@ class LmsResponse implements \JsonSerializable {
         $this->contentType = (isset($headers['content-type'][0])) ? $headers['content-type'][0] : false;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'content' => $this->getContent(),

--- a/src/Response/ApiResponse.php
+++ b/src/Response/ApiResponse.php
@@ -62,7 +62,7 @@ class ApiResponse implements \JsonSerializable
         $this->html = $html;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'messages' => $this->getMessages(),


### PR DESCRIPTION
PHP 8 requires types for `jsonSerialize()` methods. The other commit converts the deprecated Serializable interface into the `__serialize()` and `__deserialize()` methods, which are the supported way in PHP 8.