### PR TITLE
Fix auto scripts warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,16 +96,6 @@
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php56": "*"
     },
-    "scripts": {
-        "auto-scripts": {
-        },
-        "post-install-cmd": [
-            "@auto-scripts"
-        ],
-        "post-update-cmd": [
-            "@auto-scripts"
-        ]
-    },
     "conflict": {
         "symfony/symfony": "*"
     },


### PR DESCRIPTION
When you run `composer install`, you get a warning about auto-scripts. We aren't using that feature anyway, so this removes it to fix the warning.