### PR TITLE
Bring changes from Cidilabs docker setup to UCF UDOIT

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,12 +1,12 @@
 ###> symfony/framework-bundle ###
-APP_ENV=prod
+APP_ENV=dev
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:root@db:3306/udoit3
 
 ###> base url ###
 # Base URL for client callbacks 
-BASE_URL="https://127.0.0.1:8000"
+BASE_URL="https://localhost"
 ###> base url ###
 
 APP_LMS=canvas

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+/database*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        libpq-dev \
         unzip \
         wget \
         supervisor \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure gd  \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql
 
 #Install Libre Office
@@ -41,8 +43,6 @@ RUN mkdir -p /var/www/html \
 
 #install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-
-COPY deploy/supervisor/messenger-worker.conf /etc/supervisor/conf.d/messenger-worker.conf
 
 #Install symfony
 RUN wget https://get.symfony.com/cli/installer -O - | bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,6 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install pdo_pgsql
 
-#Install AWS CLI v2
-RUN if [ "$ENVIRONMENT_TYPE" != "local" ] ;then  \
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-        && unzip awscliv2.zip \
-        && ./aws/install \
-        && rm -r aws* \
-    ;fi
-
 #Install Libre Office
 RUN if [ "$LIBRE_INSTALL" = "TRUE" ];then apt install -y libreoffice ;else echo "Libre Office was not installed"; fi
 

--- a/deploy/udoit-ng.sh
+++ b/deploy/udoit-ng.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # change to the new file location
 cd /var/www/html
@@ -6,7 +6,13 @@ cd /var/www/html
 # copy localConfig from S3 if you are not on local
 if [ "$ENVIRONMENT_TYPE" != "local" ]
 then
-    aws s3 cp s3://cidilabs-devops/udoit3/.env.local.$ENVIRONMENT_TYPE /var/www/html/.env.local
+    ##PLACEHOLDER FOR COPYING down .env.local from somewhere when it's not on local##
+    # aws s3 cp s3://$S3_BUCKET/udoit/.env.local.$ENVIRONMENT_TYPE /var/www/html/.env.local
+
+    # create .user.ini file for New Relic (PHP-FPM only)
+    touch /var/www/html/public/.user.ini
+    # add New Relic appname 
+    echo -e "\nnewrelic.appname = \"$NEW_RELIC_APP_NAME\"" >> /var/www/html/public/.user.ini
 fi
 
 # run composer install
@@ -14,15 +20,6 @@ composer install --no-dev --no-interaction --no-progress --optimize-autoloader
 
 # change all file and directory permissions to give apache sufficient access
 sudo find /var/www/html -type f -exec chmod 664 {} + -o -type d -exec chmod 775 {} +
-
-# only setup newrelic if not on local.
-if [ "$ENVIRONMENT_TYPE" != "local" ]
-then
-    # create .user.ini file for New Relic (PHP-FPM only)
-    touch /var/www/html/public/.user.ini
-    # add New Relic appname 
-    echo -e "\nnewrelic.appname = \"$NEW_RELIC_APP_NAME\"" >> /var/www/html/public/.user.ini
-fi
 
 # compile JS
 yarn install
@@ -32,4 +29,7 @@ yarn run encore dev
 /usr/bin/supervisord
 
 # restart apaches
-# apachectl restart
+apachectl restart
+
+#Start PHP-FPM
+php-fpm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '3.3'
 
 services:
   db:
-    image: mysql:latest
+    image: mariadb:latest
     volumes:
       - ./database/data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: udoit3
-      MYSQL_USER: udoit
-      MYSQL_PASSWORD: udoit
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: udoit3
+      MARIADB_USER: udoit
+      MARIADB_PASSWORD: udoit
     ports:
       - "3306:3306"
   # Uncomment this block and comment the next db block

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
   php:
     build:
       context: .
-      args:
-        - LIBRE_INSTALL=TRUE
+      # args:
+      #   - LIBRE_INSTALL=TRUE
       dockerfile: Dockerfile
     volumes:
       - .:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,11 +26,18 @@ services:
   php:
     build:
       context: .
+      args:
+        - LIBRE_INSTALL=TRUE
       dockerfile: Dockerfile
     volumes:
       - .:/var/www/html
+      - .env.local.example:/var/www/html/.env.local
     ports:
-      - "8000:8000"
+      - "80:80"
+      - "443:443"
+    environment:
+      - ENVIRONMENT_TYPE=local
+
 volumes:
   web:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: mysql:latest
     volumes:
-      - dbdata:/var/lib/mysql
+      - ./database/data:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: udoit3
@@ -37,7 +37,3 @@ services:
       - "443:443"
     environment:
       - ENVIRONMENT_TYPE=local
-
-volumes:
-  web:
-  dbdata:


### PR DESCRIPTION
This is to bring changes made inside of Cidi Labs Docker setup to UCF.
There are still many questions. 

- If this is to be cloud agnostic then we really don't need to install AWS CLI tools.
- I am also not sure but for cloud versions you can do the builds in the Dockerfiles but Docker Compose and any files mounts get mounted after builds which will overwrite things like composer/yarn installs.
- The entrypoint script that is ran was changed to make sure you can run commands during startup of the container. Running it as a RUN defeats the purpose of the script and makes it part of the BUILD phase instead of in the actual container. 
