### PR TITLE
#854 flatten items from multiple array and merge into one single array

### DIFF
--- a/src/Lms/LmsResponse.php
+++ b/src/Lms/LmsResponse.php
@@ -55,7 +55,7 @@ class LmsResponse implements \JsonSerializable {
             $this->contentString .= $content;
         }
         else {            
-            $this->contentArray = array_merge($this->contentArray, $results);
+            $this->contentArray = array_merge_recursive($this->contentArray, $results);
         }
     }
 


### PR DESCRIPTION
Addressing #854 

The paged Canvas terms API call returns multiple arrays. 

This fix is to flatten the arrays and merge all items from all arrays. Multiple arrays are returned because UM has 101 academic terms returns, so that becomes two arrays since the default array size is 100 in Canvas api calls.