### PR TITLE
Remove `ContentPage.getDerviedStateFromProps` to fix navigation bug (#644)

### DIFF
--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -77,17 +77,6 @@ class ContentPage extends React.Component {
     }
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const stateActiveIssue = state.activeIssue
-    const propsActiveIssue = stateActiveIssue && props.report.issues[stateActiveIssue.id]
-    if(propsActiveIssue && propsActiveIssue.status !== stateActiveIssue.status) {
-      return {
-        activeIssue: propsActiveIssue
-      }
-    }
-    return null
-  }
-
   handleSearchTerm = (e, val) => {
     this.setState({searchTerm: val, filteredIssues: [], tableSettings: Object.assign({}, this.state.tableSettings, {pageNum: 0})});
   }


### PR DESCRIPTION
This PR aims to resolve #644. It is currently a draft but I hope to open it for review shortly.

# Explanation

The `getDerivedStateFromProps` method in the `ContentPage` component was introduced in this commit: https://github.com/ucfopen/UDOIT/commit/baf5f0e301d41cf89cb51c87023bddf07bb668a9 My colleague from University of Michigan @jonespm did a good job analyzing and explaining the issue, but I'll do so here for completeness.

Inside this method, there is a usage of `issue.id` as an index for finding an issue in `report.issues` with the same ID. Order in this array and ID are not equivalent. The result is that, in scenarios where the ID is small enough that it could also be an index (if it's not small enough, in JavaScript, accessing an invalid index results in `undefined`), the method ends up comparing two different issues. If one of the issues is fixed or resolved (i.e. it has a different `status`), the issue from the incorrect indexing supersedes, leading to a jumping of indexes in the UI to a completely unrelated issue.

@jonespm proposed initially in PR #853 that we use `find` as a replacement for the logic here. That would likely work fine, but I haven't yet figured out what value this method adds. It's supposed to update the `activeIssue` state of `ContentPage` if what it receives from `props` is different from what it has in internal state. Okay, cool, but shouldn't that state already be updated by `ContentPage.handleActiveissue`, which is called in several places in `UFixitModal` and its children. Since this method hasn't been functioning as intended, I'm inclined to think it's not necessary at all, but let me know if I'm missing something here.

*Note*: there are other issues with the navigation that leads to index jumping, but usually it's just the result of recently state not being kept beyond the first (see #887) or within a content item grouping (something I think @taheralfayad was working and I will try to document). I feel these should be addressed separately.

# Testing instructions

I will add some testing instructions here shortly. You may find it useful to apply the following diff so that the issue ID is visible in the modal, in the header.

```
diff --git a/assets/js/Components/UfixitModal.js b/assets/js/Components/UfixitModal.js
index cfa1e03f..f05c43d4 100644
--- a/assets/js/Components/UfixitModal.js
+++ b/assets/js/Components/UfixitModal.js
@@ -106,7 +106,7 @@ class UfixitModal extends React.Component {
           <Modal.Header padding="0 medium">
             <Flex>
               <Flex.Item shouldGrow shouldShrink>
-                <Heading>{this.props.t(`rule.label.${activeIssue.scanRuleId}`)}</Heading>
+                <Heading>{this.props.t(`rule.label.${activeIssue.scanRuleId}`)} (issue ID: {activeIssue.id})</Heading>
               </Flex.Item>
               <Flex.Item>
                 <CloseButton
```

# Resources
- https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
