### PR TITLE
Keep recently changed issues in `UFixitModal` (#887)

### DIFF
--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -219,13 +219,13 @@ class App extends React.Component {
   handleIssueSave(newIssue, newReport) {
     const oldReport = this.state.report;
 
-    const report = {...oldReport, ...newReport};
+    const report = { ...oldReport, ...newReport };
 
     if (report && Array.isArray(report.issues)) {
       // Combine backend issues with frontend issue state
       report.issues = report.issues.map((issue) => {
         if (issue.id === newIssue.id) return newIssue;
-        const oldIssue = oldReport.issues.find(oldReportIssue => oldReportIssue.id === issue.id);
+        const oldIssue = oldReport.issues.find((oldReportIssue) => oldReportIssue.id === issue.id);
         return oldIssue !== undefined ? { ...oldIssue, ...issue } : issue;
       });
     }

--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -217,14 +217,20 @@ class App extends React.Component {
   }
 
   handleIssueSave(newIssue, newReport) {
-    let { report } = this.state
-    report = {...report, ...newReport}
+    const oldReport = this.state.report;
+
+    const report = {...oldReport, ...newReport};
 
     if (report && Array.isArray(report.issues)) {
-      report.issues = report.issues.map(issue => (issue.id == newIssue.id) ? newIssue : issue)
+      // Combine backend issues with frontend issue state
+      report.issues = report.issues.map((issue) => {
+        if (issue.id === newIssue.id) return newIssue;
+        const oldIssue = oldReport.issues.find(oldReportIssue => oldReportIssue.id === issue.id);
+        return oldIssue !== undefined ? { ...oldIssue, ...issue } : issue;
+      });
     }
 
-    this.setState({ report })
+    this.setState({ report });
   }
 
   handleFileSave(newFile, newReport) {

--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -102,9 +102,17 @@ class ContentPage extends React.Component {
   }
 
   handleCloseButton = () => {
+    const newReport = { ...this.props.report };
+    newReport.issues = newReport.issues.map(issue => {
+      issue.recentlyResolved = false;
+      issue.recentlyUpdated = false;
+      return issue;
+    });
+
     this.setState({
+      report: newReport,
       modalOpen: false
-    })
+    });
   }
 
   handleTrayToggle = (e, val) => {

--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -103,7 +103,7 @@ class ContentPage extends React.Component {
 
   handleCloseButton = () => {
     const newReport = { ...this.props.report };
-    newReport.issues = newReport.issues.map(issue => {
+    newReport.issues = newReport.issues.map((issue) => {
       issue.recentlyResolved = false;
       issue.recentlyUpdated = false;
       return issue;


### PR DESCRIPTION
This PR aims to resolve #887. It is still a draft.

The changes here make it so multiple issues that have been fixed or resolved remain in the open `UFixitModal`. (In constrast, the code in `main` only keeps the most recently changed issue in the modal.) This is intended to assist users in reviewing their work (or potentially un-doing resolves, though that is currently problematic, see #867). It also prevents indexes in the bottom-left of the modal from shrinking by one (because previously fixed or resolved issues aren't being filtered out).

The recent state of the issues is set to `false` when the modal is closed; thus these "recently updated" issues will not appear in the modal if it is closed and re-opened. That's a departure from current behavior where the most recently updated issue would still appear if you close and reopen the modal with the same filters. My feeling is that clearing this on close would be the expected behavior, but that may be incorrect. Certainly it didn't make sense to keep all updated issues in recent state forever (or at least until the application is refreshed/re-scanned).

Some of these decisions/assumptions could benefit from being tested by UX folks.