### PR TITLE
Remove "Fixed HTML was not replaced in LMS." message

### DIFF
--- a/src/Services/LmsPostService.php
+++ b/src/Services/LmsPostService.php
@@ -51,11 +51,6 @@ class LmsPostService {
 
         $replaceSuccess = $this->replaceContent($issue, $contentItem);
         if (!$replaceSuccess) {
-            $this->util->createMessage(
-                'Fixed HTML was not replaced in LMS. Please contact an administrator.',
-                'error',
-                $contentItem->getCourse()
-            );
             return;
         }
 


### PR DESCRIPTION
Fixes #896 

### **Reasoning behind removal:**

Currently, whenever UDOIT reports an issue and the user decides to fix the issue manually and changes the HTML causing that particular issue, UDOIT just returns a "Fixed HTML was not replaced in LMS" message, which would then prevent the issue from being resolved, due to this block of code in IssuesController.php:
```
// Add messages to response
$unreadMessages = $util->getUnreadMessages();
if (empty($unreadMessages)) {
```
This is causing issues because it prevents the workflow of fixing the issue and then marking it as resolved. Currently, mark as resolved just means ignore the issue, which is somewhat misleading to a person who wants to actually manually resolve an issue. The current workaround which we've developed is to first mark the issue as resolved and then change its HTML, but this change also allows us to switch the order of operations