### PR TITLE
Specify a specific stack (stack-20) for classic app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name": "UDOIT",
   "description": "The Universal Design Online content Inspection Tool, or UDOIT identifies and fixes accessibility issues in Canvas by Instructure.",
+  "stack": "heroku-20",
   "keywords": [
     "education",
     "canvas",


### PR DESCRIPTION
classic doesn't currently build on Stack 22 but it does work fine on 20.

Stack 20 is supported until April 2025: https://devcenter.heroku.com/articles/stack


