### PR TITLE
Update nginx configurations and php.ini to increase maximum file size.

### DIFF
--- a/assets/js/Components/FilesModal.js
+++ b/assets/js/Components/FilesModal.js
@@ -77,7 +77,7 @@ class FilesModal extends React.Component {
         break
 
       default:
-        accept = fileType
+        accept = file.fileType
         break
     }
 

--- a/assets/js/Components/FilesModal.js
+++ b/assets/js/Components/FilesModal.js
@@ -249,6 +249,13 @@ class FilesModal extends React.Component {
       return
     }
 
+    if(file.size > 1024 * 1024 * 10) {
+      this.addMessage({severity: 'error', message: this.props.t('msg.file.replace.file_size'), timeout: 5000})
+      this.setState({ replaceFileObj: null })
+      this.forceUpdate()
+      return
+    }
+
     this.setState({ replaceFileObj: file })
   }
 

--- a/build/nginx/deploy.conf
+++ b/build/nginx/deploy.conf
@@ -9,6 +9,7 @@ server {
 
         rewrite ^/udoit3/(.*)$ /$1 break;
         try_files $uri @symfonyFront;
+        client_max_body_size 10M;
     }
     
     set $symfonyRoot /var/www/html/public;

--- a/build/nginx/local.conf
+++ b/build/nginx/local.conf
@@ -9,6 +9,7 @@ server {
 
         rewrite ^/udoit3/(.*)$ /$1 break;
         try_files $uri @symfonyFront;
+        client_max_body_size 10M;
     }
     
     set $symfonyRoot /var/www/html/public;

--- a/build/nginx/php-custom.ini
+++ b/build/nginx/php-custom.ini
@@ -1,2 +1,4 @@
 max_execution_time = 180
 memory_limit = 800M
+upload_max_filesize = 10M
+post_max_size = 10M

--- a/translations/en.json
+++ b/translations/en.json
@@ -133,6 +133,7 @@
   "msg.sync.started": "Course scan started.",
   "msg.sync.failed": "Course scan failed. Course is missing.",
   "msg.file.replace.file_type": "File type not accepted. Please input a file with the correct filetype.",
+  "msg.file.replace.file_size": "File size too large. Please input a file with a size less than 10MB",
   "msg.sync.completed": "Course scan completed.",
   "msg.sync.course_inactive": "Course scan failed. Course is inactive.",
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -133,7 +133,7 @@
   "msg.sync.started": "Course scan started.",
   "msg.sync.failed": "Course scan failed. Course is missing.",
   "msg.file.replace.file_type": "File type not accepted. Please input a file with the correct filetype.",
-  "msg.file.replace.file_size": "File size too large. Please input a file with a size less than 10MB",
+  "msg.file.replace.file_size": "File size too large. Please input a file of a size less than 10MB",
   "msg.sync.completed": "Course scan completed.",
   "msg.sync.course_inactive": "Course scan failed. Course is inactive.",
 

--- a/translations/es.json
+++ b/translations/es.json
@@ -133,6 +133,7 @@
   "msg.sync.started": "Se inició el escaneo del curso.",
   "msg.sync.failed": "Falló el escaneo del curso. Falta el curso.",
   "msg.file.replace.file_type": "El tipo de archivo no es válido. Por favor aporte un archivo de tipo correcto.",
+  "msg.file.replace.file_size": "El tamaño del archivo es demasiado grande. Por favor aporte un archivo de tamaño menor a 10MB",
   "msg.sync.completed": "Escaneo del curso completado.",
   "msg.sync.course_inactive": "Falló el escaneo del curso. El curso está inactivo.",
 


### PR DESCRIPTION
Fixes #942. In this current iteration of UDOIT, the maximum file size that the user is allowed to upload to a course is 1MB, which renders the file replacement modal useless for most PDFs. What currently happens when you try to upload a file that is >1MB is that UDOIT returns an unhandled 413 error, which isn't really that informative to the user. To combat that, I set the acceptable upload file size to 10MB in the nginx configurations for `local.conf` and `deploy.conf`. I also set `upload_max_filesize` and `post_max_size` to be 10MB in `php-custom.ini`.