### PR TITLE
Improve install docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,26 +2,27 @@
 UDOIT can be installed on your own existing servers with the following instructions. UDOIT is also available as a hosted and maintained product by [Cidi Labs](https://cidilabs.com). UDOIT is built using the [PHP Symfony Framework](https://symfony.com).
 
 ## System Requirements
-The system requirements depend on how you install UDOIT.  If you use Docker, the host system doesn't require any additional software.
+The system requirements depend on how you install UDOIT.
 
 ### Docker Method
 * Docker
 * Docker Compose
+* Cmake (This is available on most systems by default)
 
 ### Manual Installation Method
 * Apache or Nginx webserver
 * PHP 8.1, 8.2
 * MySQL, MariaDB or PostgreSQL
 * Git (If you are using The Git Method below) or if you plan on contributing to UDOIT
-* Node v16 is supported; other versions may work
+* Node v16 is supported; later versions may work
 * Yarn
 
 ## Download the Code
-### Option 1: Git
-We strongly recommend managing the source code through Git. The benefit of this method is that you can update an existing installation of UDOIT by simply using `git pull`. It also lets you roll back to previous versions if needed. Follow these steps:
+### Option 1: Git (Strongly recommended)
+This method is strongly recommend as it allows UDOIT to be updated through a simple command on the terminal: `git pull`. It also lets you roll back to previous versions if needed. Follow these steps:
 
 1. Install Git on your server (https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-2. Create the directory in which UDOIT will reside (e.g `UDOIT`) and navigate to it.
+2. Create a folder/directory in which UDOIT will reside (e.g `UDOIT`) and navigate to it.
 3. Inside the UDOIT directory, run `git clone git@github.com:ucfopen/UDOIT.git . ` (The . is important; It tells Git to download the files to the current directory.)
 
 ### Option 2: Zip File
@@ -36,18 +37,14 @@ cp .env.example .env
 ```
 This command copies the `.env.example` into `.env`, creating the `.env` file in the process if it does not exist.
 
-2. Open `.env` with a text editor and make the necessary changes to the following variables:
-	- `APP_ENV`: If you are setting up a development environment, change this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages. Otherwise, leave it as `prod`.
-	- `DATABASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to your database URL.
-	- `BASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to the URL of your instance of UDOIT.
-	- `WEBPACK_PUBLIC_PATH`: Uf you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to match the `BASE_URL`in such a way that `/build` is located at the root of the `BASE_URL` (Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`).
-	- `APP_LMS`:
-	   * `canvas` for Canvas LMS.
-	   * `d2l` for D2l Brightspace LMS.
-	- `JWK_BASE_URL`: If you are self-hosting Canvas, you may set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
-	- `DEFAULT_LANG`: (optional) the default language of UDOIT. This is English by default.
-		-  `en` for English
-		-  `es` for Spanish.
+2. Open `.env` with a text editor (i.e. Notepad, VS Code, etc.) and make the necessary changes to the following variables:
+- `APP_ENV`: If you are setting up a development environment, change this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages. Otherwise, leave it as `prod`.
+- `DATABASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to your database URL.
+- `BASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to the URL of your instance of UDOIT.
+- `WEBPACK_PUBLIC_PATH`: Uf you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to match the `BASE_URL`in such a way that `/build` is located at the root of the `BASE_URL` (Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`).
+	- `APP_LMS`: `canvas` for Canvas LMS. `d2l` for D2l Brightspace LMS.
+- `JWK_BASE_URL`: If you are self-hosting Canvas, you may set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
+	- `DEFAULT_LANG`: (optional)  `en` for English. `es` for Spanish. This is English by default.
 
 ## Installation
 
@@ -57,32 +54,30 @@ We provide a fast and simple way of setting up a local UDOIT instance through Do
 1. Install [Docker Desktop](https://docs.docker.com/get-docker/). This will install Docker and Docker Compose on your system. 
 	> Alternatively, you may install Docker and [Docker Compose](https://docs.docker.com/compose/install/) individually.
 
-3. Build the Containers
-If you prefer to build the containers yourself, or you are actively developing UDOIT and need to rebuild the containers to test your changes, run the following command from within the UDOIT directory:
+2. Build the Containers
 ```
-    docker compose -f docker-compose.nginx.yml up
+    make start
 ```
 
-4. Wait for the containers to finish initializing. This may take over 15 minutes. If you see no output in your terminal for few minutes, proceed to the next step.
-
-5. Once the containers are intialized, run the following command:
+3. Once the containers are intialized, run the following command:
 ```
-    docker compose -f docker-compose.nginx.yml run php php bin/console doctrine:migrations:migrate
+    make migrate
 ```
 This applies migrations necessary to set up the database to store all UDOIT data.
 
 Running this will give the following warning:
- > WARNING! You are about to execute a migration in database "udoit3" that could result in schema changes and data loss. Are you sure you wish to continue? (yes/no) [yes]:
 
-Don't worry! Simply type `yes` and proceed.
+> WARNING! You are about to execute a migration in database "udoit3" that could result in schema changes and data loss. Are you sure you wish to continue? (yes/no) [yes]:
 
-> You will need to run this command whenever you update to a new version of UDOIT.
+Type `yes` and proceed. The warning is expected and is a non issue.
 
-5. UDOIT should be installed and running in your Docker cotnainer. 
+> Note: You will need to run this command whenever you update to a new version of UDOIT.
 
-6. To stop UDOIT, run the following command:
+4. UDOIT should be installed and running in your Docker cotnainer.
+
+5. To stop UDOIT, run the following command:
 ```
-    docker compose -f docker-compose.nginx.yml down
+    make down
 ```
 
 ### Option 2. Manual Installation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ We provide a fast and simple way of setting up a local UDOIT instance through Do
     make start
 ```
 
-3. Once the containers are intialized, run the following command:
+3. Once the containers are initialized, run the following command:
 ```
     make migrate
 ```
@@ -75,7 +75,7 @@ Type `yes` and proceed. The warning is expected and is a non issue.
 
 4. UDOIT should be installed and running as Docker containers.
 
-5. To stop UDOIT containers, run the following command:
+5. To stop the UDOIT containers, run the following command:
 ```
     make down
 ```
@@ -124,7 +124,7 @@ To build the JavaScript files for production, run the command:
     yarn build
 
 ## Testing successful installation
-While UDOIT only functions fully within an LMS, there is one URL publicly available you can access to test your server setup.
+While UDOIT is an LTI tool that only functions fully within an LMS, you can plug the following URL in your browser to test if UDOIT is installed correctly:
 
     <BASE_URL>/lti/config
 
@@ -134,6 +134,6 @@ For example, if you are setting this up on your local computer via Docker, it ma
 
 
 ## Connecting UDOIT to an LMS
-UDOIT is an LTI tool that functions fully within an LMS. 
+UDOIT is an LTI tool that functions fully within an LMS. To configure it fully within your LMS, follow the installations instructions below that apply to you.
 - To install it on Canvas, follow [INSTALL_CANVAS.md](INSTALL_CANVAS.md)
 - or for D2l Brightspace, follow [INSTALL_D2L.md](INSTALL_D2L.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,78 +20,87 @@ The system requirements depend on how you install UDOIT.  If you use Docker, the
 ### Option 1: Git
 We strongly recommend managing the source code through Git. The benefit of this method is that you can update an existing installation of UDOIT by simply using `git pull`. It also lets you roll back to previous versions if needed. Follow these steps:
 
-1. Install Git on your server
-2. Navigate to the directory on your server where UDOIT will live
-3. Run `git clone git@github.com:ucfopen/UDOIT.git . ` (The . is important. It tells Git to download the files to the current directory.)
+1. Install Git on your server (https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+2. Create the directory in which UDOIT will reside (e.g `UDOIT`) and navigate to it.
+3. Inside the UDOIT directory, run `git clone git@github.com:ucfopen/UDOIT.git . ` (The . is important; It tells Git to download the files to the current directory.)
 
 ### Option 2: Zip File
-If you prefer not to use Git, you can download a zip file of the latest release from the [Releases Page](https://github.com/ucfopen/UDOIT/releases).  Unzip it in the directory on your server where UDOIT will live.
+If you prefer not to use Git, you can download the zip file of the latest release from the [Releases Page](https://github.com/ucfopen/UDOIT/releases).  Unzip it in the directory in which UDOIT will reside.
 
 ## .ENV Setup
-UDOIT uses a `.env` file for storing configuration variables. To create it:
+UDOIT stores configuration variables in a `.env` file. To create it:
 
-1. Copy the file `.env.example` to `.env` by running
+1. Inside the UDOIT directory, run the following command in shell:
 ```
 cp .env.example .env
 ```
-2. Leave `APP_ENV` set to `prod`
-> If you are setting up a development environment, set this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages.
-3. Add your database information to the `DATABASE_URL` variable.  (The default value of `mysql://root:root@db:3306/udoit3` is suitable for running it on your local computer using Docker.)
-4. Modify the `BASE_URL` to match the URL of your instance of UDOIT.  (The default value of `http://127.0.0.1:8000/udoit3` is suitable for running it on your local computer using Docker.)
-5. Modify the `WEBPACK_PUBLIC_PATH` to match the `BASE_URL` you set.  (The default value of `/udoit3/build` is suitable for running it on your local computer usind Docker.  Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`.)
-6. Set `APP_LMS` to the name of your LMS.
-   * `canvas` if you are using the Canvas LMS.
-   * `d2l` if you are using the D2l Brightspace LMS.
-7. If you are using UDOIT with a self-hosted instance of Canvas, you can add the `JWK_BASE_URL` variable and set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
-8. (Optional) You can change the default language for your entire UDOIT instance by adding the `DEFAULT_LANG` variable. Currently supported languages are English (`en`) and Spanish (`es`).
+This command copies the `.env.example` into `.env`, creating the `.env` file in the process if it does not exist.
 
-## Docker
-We provide a fast and simple way of setting up a local UDOIT instance through the use of Docker containers.
+2. Open `.env` with a text editor and make the necessary changes to the following variables:
+	- `APP_ENV`: If you are setting up a development environment, change this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages. Otherwise, leave it as `prod`.
+	- `DATABASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to your database URL.
+	- `BASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to the URL of your instance of UDOIT.
+	- `WEBPACK_PUBLIC_PATH`: Uf you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to match the `BASE_URL`in such a way that `/build` is located at the root of the `BASE_URL` (Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`).
+	- `APP_LMS`:
+	   * `canvas` for Canvas LMS.
+	   * `d2l` for D2l Brightspace LMS.
+	- `JWK_BASE_URL`: If you are self-hosting Canvas, you may set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
+	- `DEFAULT_LANG`: (optional) the default language of UDOIT. This is English by default.
+		-  `en` for English
+		-  `es` for Spanish.
 
-### 1. Install Docker
-To set up the docker containers, you must first install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
+## Installation
 
-### 2. Build the Containers
-If you prefer to build the containers yourself, or you are actively developing UDOIT and need to rebuild the containers to test your cahnges, run the following command from within the UDOIT directory:
+### Option 1. Docker
+We provide a fast and simple way of setting up a local UDOIT instance through Docker.
 
+1. Install [Docker Desktop](https://docs.docker.com/get-docker/). This will install Docker and Docker Compose on your system. 
+	> Alternatively, you may install Docker and [Docker Compose](https://docs.docker.com/compose/install/) individually.
+
+3. Build the Containers
+If you prefer to build the containers yourself, or you are actively developing UDOIT and need to rebuild the containers to test your changes, run the following command from within the UDOIT directory:
+```
     docker compose -f docker-compose.nginx.yml up
+```
 
-### 3. Wait
-Wait for all of the containers to finish initializing.  This can take over 15 minutes.  You will know you are ready to proceed with the next step when you haven't seen any output in your terminal for a few minutes.
+4. Wait for the containers to finish initializing. This may take over 15 minutes. If you see no output in your terminal for few minutes, proceed to the next step.
 
-### 4. Set up the Database
-The first time you start the containers, you will need to set up the database to handle all the information UDOIT generates as it runs.  Run the following command:
-
+5. Once the containers are intialized, run the following command:
+```
     docker compose -f docker-compose.nginx.yml run php php bin/console doctrine:migrations:migrate
+```
+This applies migrations necessary to set up the database to store all UDOIT data.
 
-> You will also need to run that command whenever you update to a new version of UDOIT.
+Running this will give the following warning:
+ > WARNING! You are about to execute a migration in database "udoit3" that could result in schema changes and data loss. Are you sure you wish to continue? (yes/no) [yes]:
 
-### 5. Next steps
-Skip to [Testing your Setup](#testing-your-setup) to continue.
+Don't worry! Simply type `yes` and proceed.
 
-### 6. Stopping the Containers
-If you ever want to stop the containers, you can do so with the following command:
+> You will need to run this command whenever you update to a new version of UDOIT.
 
+5. UDOIT should be installed and running in your Docker cotnainer. 
+
+6. To stop UDOIT, run the following command:
+```
     docker compose -f docker-compose.nginx.yml down
+```
 
-
-
-## Manual Installation
+### Option 2. Manual Installation
 If you prefer not to use Docker, the process is more complicated:
 
-### Configuring your Web Server
+1. Configuring your Web Server
 The details of configuring a web server with PHP are out of the scope of this README. You should configure your web server to point to UDOIT's "public" folder as the web root folder. Doing this will hide the configuration and source files so that they are not web accessible. It will also clean up your URL structure so that you don't need to include the "public" folder in any of the URLs to UDOIT.
 
 If you are using NGINX as your web server, you can use the `build/nginx/nginx.conf` file as a starting point.
 
-### Installing Composer Dependencies
+2. Installing Composer Dependencies
 UDOIT uses Composer to install PHP dependencies. Follow the upstream documentation on [Composer Installation](https://getcomposer.org/download/) to install `composer.phar` into the project root, then run the following:
 
     php composer.phar install --no-dev
 
 > Remove the `--no-dev` flag if you set `APP_ENV=dev` in your `.env.local` file.
 
-### Database Setup
+3. Database Setup
 While UDOIT is configured to use MySQL or MariaDB by default, Symfony can be configured to work with other databases as well. See the Symfony documentation for details.
 
 Use Symfony to create the database with this command:
@@ -110,7 +119,7 @@ If you are operating in a production environment you will need to generate the d
 
     php bin/console cache:warmup --env=prod
 
-### JavaScript
+4. JavaScript
 UDOIT uses [node](https://nodejs.org) and [yarn](https://yarnpkg.com/) to compile the JavaScript. Install Node and Yarn on your system, then run:
 
     yarn install
@@ -119,10 +128,8 @@ To build the JavaScript files for production, run the command:
 
     yarn build
 
-## Testing Your Setup
-Once you have completed the steps above you will want to test your setup. Unfortunately, UDOIT is an LTI tool that can only fully run within the LMS. You will need to complete the steps in the [INSTALL_CANVAS.md](INSTALL_CANVAS.md) or [INSTALL_D2L.md](INSTALL_D2L.md) to test UDOIT fully.
-
-However, UDOIT does have one URL that is publicly available outside of the LMS. To test your server setup point your browser to:
+## Testing successful installation
+While UDOIT only functions fully within an LMS, there is one URL publicly available you can access to test your server setup.
 
     <BASE_URL>/lti/config
 
@@ -130,5 +137,8 @@ For example, if you are setting this up on your local computer via Docker, it ma
 
     http://127.0.0.1:8000/udoit3/lti/config
 
-## Configuring Your LMS
-You will need to complete the steps in the [INSTALL_CANVAS.md](INSTALL_CANVAS.md) or [INSTALL_D2L.md](INSTALL_D2L.md) to configure UDOIT to work within your LMS.
+
+## Connecting UDOIT to an LMS
+UDOIT is an LTI tool that functions fully within an LMS. 
+- To install it on Canvas, follow [INSTALL_CANVAS.md](INSTALL_CANVAS.md)
+- or for D2l Brightspace, follow [INSTALL_D2L.md](INSTALL_D2L.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,9 +73,9 @@ Type `yes` and proceed. The warning is expected and is a non issue.
 
 > Note: You will need to run this command whenever you update to a new version of UDOIT.
 
-4. UDOIT should be installed and running in your Docker cotnainer.
+4. UDOIT should be installed and running as Docker containers.
 
-5. To stop UDOIT, run the following command:
+5. To stop UDOIT containers, run the following command:
 ```
     make down
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,23 +38,25 @@ cp .env.example .env
 This command copies the `.env.example` into `.env`, creating the `.env` file in the process if it does not exist.
 
 2. Open `.env` with a text editor (i.e. Notepad, VS Code, etc.) and make the necessary changes to the following variables:
-- `APP_ENV`: If you are setting up a development environment, change this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages. Otherwise, leave it as `prod`.
-- `DATABASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to your database URL.
-- `BASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to the URL of your instance of UDOIT.
-- `WEBPACK_PUBLIC_PATH`: Uf you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to match the `BASE_URL`in such a way that `/build` is located at the root of the `BASE_URL` (Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`).
-	- `APP_LMS`: `canvas` for Canvas LMS. `d2l` for D2l Brightspace LMS.
-- `JWK_BASE_URL`: If you are self-hosting Canvas, you may set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
-	- `DEFAULT_LANG`: (optional)  `en` for English. `es` for Spanish. This is English by default.
+   - `APP_ENV`: If you are setting up a development environment, change this to `dev` and follow the steps in [Installing Composer Dependencies](#installing-composer-dependencies) without the `--no-dev` flag to obtain all of the development packages. Otherwise, leave it as `prod`.
+   - `DATABASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to your database URL.
+   - `BASE_URL`: If you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to the URL of your instance of UDOIT.
+   - `WEBPACK_PUBLIC_PATH`: Uf you are hosting UDOIT on Docker or your local machine, leave it as it is. Otherwise, change it to match the `BASE_URL`in such a way that `/build` is located at the root of the `BASE_URL` (Example:  If your `BASE_URL` is set to `http://127.0.0.1:8000`, your `WEBPACK_PUBLIC_PATH` should be `/build`).
+   	- `APP_LMS`: `canvas` for Canvas LMS. `d2l` for D2l Brightspace LMS.
+   - `JWK_BASE_URL`: If you are self-hosting Canvas, you may set it to the URL of your instance of Canvas. (Example: `JWK_BASE_URL="https://canvas.dev.myschool.edu"`)
+   	- `DEFAULT_LANG`: (optional)  `en` for English. `es` for Spanish. This is English by default.
+3. Copy the contents of `ins.env.example` over to a new file called `ins.env`, and keep it in mind for when you're asked to fill out the institutions table. The `makefile` has a command to speed up this process.
 
 ## Installation
 
-### Option 1. Docker
+### Option 1: Docker
 We provide a fast and simple way of setting up a local UDOIT instance through Docker.
 
-1. Install [Docker Desktop](https://docs.docker.com/get-docker/). This will install Docker and Docker Compose on your system. 
+1. Install [Docker Desktop](https://docs.docker.com/get-docker/). This will install Docker and Docker Compose on your system.
 	> Alternatively, you may install Docker and [Docker Compose](https://docs.docker.com/compose/install/) individually.
 
 2. Build the Containers
+
 ```
     make start
 ```
@@ -73,29 +75,31 @@ Type `yes` and proceed. The warning is expected and is a non issue.
 
 > Note: You will need to run this command whenever you update to a new version of UDOIT.
 
-4. UDOIT should be installed and running as Docker containers.
+UDOIT should be installed and running as Docker containers.
 
-5. To stop the UDOIT containers, run the following command:
+4. To stop the UDOIT containers, run the following command:
 ```
     make down
 ```
 
-### Option 2. Manual Installation
+> Please be sure to review the `makefile` for more information on what these commands do.
+
+### Option 2: Manual Installation
 If you prefer not to use Docker, the process is more complicated:
 
-1. Configuring your Web Server
-The details of configuring a web server with PHP are out of the scope of this README. You should configure your web server to point to UDOIT's "public" folder as the web root folder. Doing this will hide the configuration and source files so that they are not web accessible. It will also clean up your URL structure so that you don't need to include the "public" folder in any of the URLs to UDOIT.
+#### 1. Configuring your Web Server
+ The details of configuring a web server with PHP are out of the scope of this README. You should configure your web server to point to UDOIT's "public" folder as the web root folder. Doing this will hide the configuration and source files so that they are not web accessible. It will also clean up your URL structure so that you don't need to include the "public" folder in any of the URLs to UDOIT.
 
 If you are using NGINX as your web server, you can use the `build/nginx/nginx.conf` file as a starting point.
 
-2. Installing Composer Dependencies
+#### 2. Installing Composer Dependencies
 UDOIT uses Composer to install PHP dependencies. Follow the upstream documentation on [Composer Installation](https://getcomposer.org/download/) to install `composer.phar` into the project root, then run the following:
 
     php composer.phar install --no-dev
 
 > Remove the `--no-dev` flag if you set `APP_ENV=dev` in your `.env.local` file.
 
-3. Database Setup
+#### 3. Database Setup
 While UDOIT is configured to use MySQL or MariaDB by default, Symfony can be configured to work with other databases as well. See the Symfony documentation for details.
 
 Use Symfony to create the database with this command:
@@ -114,7 +118,7 @@ If you are operating in a production environment you will need to generate the d
 
     php bin/console cache:warmup --env=prod
 
-4. JavaScript
+#### 4. JavaScript
 UDOIT uses [node](https://nodejs.org) and [yarn](https://yarnpkg.com/) to compile the JavaScript. Install Node and Yarn on your system, then run:
 
     yarn install
@@ -134,6 +138,6 @@ For example, if you are setting this up on your local computer via Docker, it ma
 
 
 ## Connecting UDOIT to an LMS
-UDOIT is an LTI tool that functions fully within an LMS. To configure it fully within your LMS, follow the installations instructions below that apply to you.
+To configure it fully within your LMS, follow the installation instructions below that apply to you.
 - To install it on Canvas, follow [INSTALL_CANVAS.md](INSTALL_CANVAS.md)
 - or for D2l Brightspace, follow [INSTALL_D2L.md](INSTALL_D2L.md)

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -5,36 +5,29 @@ Once UDOIT has been installed on a public web server the following steps must be
 * Update the Institutions table
 * Install the application
 
-**Skills Required**
-* Ability to insert MySQL
-
 ## Create an API Developer Key
 UDOIT requires an API developer key, since all course data is gathered through the Canvas API.
 
 ### Steps to Create an API Key
-* Navigate to `Developer Keys` in the root account menu.
-* Choose to add a `Developer Key` => `API Key`
-
-Provide values for the following fields:
-* Key Name
-    * i.e. UDOIT 3 API
+1. Navigate to `Developer Keys` in the root account menu.
+2. Choose to add a `Developer Key` => `API Key`
+3. Provide values for the following fields:
+* Key Name: i.e. UDOIT 3 API
 * Owner Email
-* Redirect URIs
-    * <YOUR_UDOIT_BASE_URL>/authorize/check
+* Redirect URIs: <YOUR_UDOIT_BASE_URL>/authorize/check
+* Icon URL: <YOUR_UDOIT_BASE_URL>/build/static/udoit_logo.svg
+* Client Credentials
+* Canvas
+* Enforce Scopes
+* See section below for a list of scopes to enable.
+* Check `Allow Include Parameters`
 * Redirect URL (Legacy) : *SKIP*
 * Vendor Code : *SKIP*
-* Icon URL
-    * <YOUR_UDOIT_BASE_URL>/build/static/udoit_logo.svg
 * Notes : *Optional*
-    * These are only seen by other LMS admins
+* These are only seen by other LMS admins
 * Test Cluster Only : *SKIP*
-* Client Credentials
-    * Canvas
-* Enforce Scopes
-    * See section below for a list of scopes to enable.
-    * Check `Allow Include Parameters`
-* Save
-* Click `ON` to enable the newly created key
+4. Save
+5. Click `ON` to enable the newly created key
 
 ### Scopes
 We strongly recommend you enforce scopes with your API key. The following scopes must be enabled for UDOIT to work.
@@ -95,35 +88,25 @@ Follow the steps below, replacing `<YOUR_UDOIT_BASE_URL>` with the `BASE_URL` va
 
 1. Navigate to `Developer Keys` in the root account menu.
 2. Choose to add a `Developer Key` => `LTI Key`
-
-Provide values for the following fields:
-* Key Name
-    * i.e. UDOIT 3 LTI
+3. Provide values for the following fields:
+* Key Name: i.e. UDOIT 3 LTI
 * Owner Email
-* Redirect URIs
-    * <YOUR_UDOIT_BASE_URL>/lti/authorize/check
-* Notes : *Optional*
-    * These are only seen by other LMS admins
-* Configure method
-    * Enter URL
-* JSON URL
-    * <YOUR_UDOIT_BASE_URL>/lti/config
-* Click Save.  Reload the page, then edit the LTI key you just created.
+* Redirect URIs: <YOUR_UDOIT_BASE_URL>/lti/authorize/check
+* Configure method: Enter URL
+* JSON URL: <YOUR_UDOIT_BASE_URL>/lti/config
 * If your instance of Canvas is self-hosted, modify the URL under **JWK Method** to point to your canvas instance.
 * Set Additional Settings
-    * Domain
-      * Your UDOIT domain
-    * Tool ID
-      * Enter a name
-    * Custom Fields
-```
-lms_id=canvas
-lms_user_id=$Canvas.user.id
-lms_course_id=$Canvas.course.id
-lms_api_domain=$Canvas.api.domain
-```
-* Save
-* Click `ON` to enable the newly created key
+* Domain: Your UDOIT domain
+* Tool ID: Enter a name
+* Custom Fields
+	```
+	lms_id=canvas
+	lms_user_id=$Canvas.user.id
+	lms_course_id=$Canvas.course.id
+	lms_api_domain=$Canvas.api.domain
+	```
+4. Click Save.
+5. Click `ON` to enable the newly created key.
 
 ---
 ## Docker Compose Base URL
@@ -133,42 +116,25 @@ If you are setting up UDOIT for local development through `docker compose`, <YOU
 ## Update the Institutions Table
 UDOIT is built to support more than one LMS instance. For this purpose we have an `institution` table that must be populated with the LMS information.
 
-**Note:** This step requires knowledge of MySQL.
+1. Inside the UDOIT directory, run `cp .ins.env.example .ins.env`
+2. open `.ins.env` with a text editor (i.e. Notepad, VS Code, etc.)
+3. Fill in the fields with the appropriate values
+- `TITLE` = Your institution's name
+- `LMS_DOMAIN` = The Canvas domain name of your institution (i.e. `myschool.instructure.com`)
+- `LMS_ID` = `canvas`
+- `LMS_ACCOUNT_ID` = The Canvas account ID (as a string) where UDOIT will be installed
+- `CREATED` = Date in this format: `2021-06-08`
+- `STATUS` = `1` if you are using MySQL or MariaDB (or Docker), `true` if you are using PostgreSQL
+- `VANITY_URL` = Your LMS vanity URL (i.e. `canvas.myschool.edu`)
+- `METADATA` = Optional. Institution specific settings, such as language or excluded tests. Text representation of a JSON object. (i.e. `{"lang":"es"}`)
+- `API_CLIENT_ID` = The ID of the developer API key you created earlier
+- `API_CLIENT_SECRET` = The secret for the API key you created earlier
 
-The following fields need to be populated in the `institution` table.
-* title
-    * Your institution's name
-* lms_domain
-    * The Canvas domain name of your institution.
-    * Most institutions will use their `.instructure.com` domain.
-    * Do not include `https://` or a trailing slash.
-    * Example: `myschool.instructure.com`
-* lms_id
-    * `canvas`
-* lms_account_id
-    * The Canvas account ID (as a string) where UDOIT will be installed.
-* created
-    * Date in this format: `2021-06-08`
-* status
-    * `1` if you are using MySQL or MariaDB (or Docker)
-    * `true` if you are using PostgreSQL
-* vanity_url
-    * Your LMS vanity URL
-    * Example: `canvas.myschool.edu`
-* metadata
-    * Optional
-    * Institution specific settings, such as language or excluded tests.
-    * Text representation of a JSON object.
-    * Example: `{"lang":"es"}`
-    * Currently supported languages are English (en) and Spanish (es).
-* api_client_id
-    * The ID of the developer API key you created earlier.
-    * Client ID is found in the `Details` column on the Developer Keys page
-    * Example: 1234500000000001234
-* api_client_secret
-    * The secret for the API key you created earlier.
-    * Click `Show Key` on the API key you created earlier.
-    * This key will be stored encrypted on the first use of the key.
+4. Run the following command:
+```
+make ins-mysql	# For MySQL or MariaDB
+make ins-psql	# For PostgreSQL
+```
 
 ---
 ## .ENV Setup

--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -6,7 +6,7 @@ Once UDOIT has been installed on a public web server the following steps must be
 * Install the application
 
 ## Create an API Developer Key
-UDOIT requires an API developer key, since all course data is gathered through the Canvas API.
+UDOIT requires an API developer key since all course data is gathered through the Canvas API.
 
 ### Steps to Create an API Key
 1. Navigate to `Developer Keys` in the root account menu.
@@ -19,7 +19,7 @@ UDOIT requires an API developer key, since all course data is gathered through t
 * Client Credentials
 * Canvas
 * Enforce Scopes
-* See section below for a list of scopes to enable.
+* See the section below for a list of scopes to enable.
 * Check `Allow Include Parameters`
 * Redirect URL (Legacy) : *SKIP*
 * Vendor Code : *SKIP*
@@ -94,7 +94,7 @@ Follow the steps below, replacing `<YOUR_UDOIT_BASE_URL>` with the `BASE_URL` va
 * Redirect URIs: <YOUR_UDOIT_BASE_URL>/lti/authorize/check
 * Configure method: Enter URL
 * JSON URL: <YOUR_UDOIT_BASE_URL>/lti/config
-* If your instance of Canvas is self-hosted, modify the URL under **JWK Method** to point to your canvas instance.
+* If your instance of Canvas is self-hosted, modify the URL under **JWK Method** to point to your Canvas instance.
 * Set Additional Settings
 * Domain: Your UDOIT domain
 * Tool ID: Enter a name
@@ -114,7 +114,7 @@ If you are setting up UDOIT for local development through `docker compose`, <YOU
 
 ---
 ## Update the Institutions Table
-UDOIT is built to support more than one LMS instance. For this purpose we have an `institution` table that must be populated with the LMS information.
+UDOIT is built to support more than one LMS instance. For this purpose, we have an `institution` table that must be populated with the LMS information.
 
 1. Inside the UDOIT directory, run `cp .ins.env.example .ins.env`
 2. open `.ins.env` with a text editor (i.e. Notepad, VS Code, etc.)
@@ -126,7 +126,7 @@ UDOIT is built to support more than one LMS instance. For this purpose we have a
 - `CREATED` = Date in this format: `2021-06-08`
 - `STATUS` = `1` if you are using MySQL or MariaDB (or Docker), `true` if you are using PostgreSQL
 - `VANITY_URL` = Your LMS vanity URL (i.e. `canvas.myschool.edu`)
-- `METADATA` = Optional. Institution specific settings, such as language or excluded tests. Text representation of a JSON object. (i.e. `{"lang":"es"}`)
+- `METADATA` = Optional. Institution-specific settings, such as language or excluded tests. Text representation of a JSON object. (i.e. `{"lang":"es"}`)
 - `API_CLIENT_ID` = The ID of the developer API key you created earlier
 - `API_CLIENT_SECRET` = The secret for the API key you created earlier
 
@@ -138,7 +138,7 @@ make ins-psql	# For PostgreSQL
 
 ---
 ## .ENV Setup
-For cloud-hosted canvas instances the default value for the `JWK_BASE_URL` environmental variable will work out of the box. If you are not cloud-hosted, you may need to change the value of this variable in `.env.local` to match your canvas instance.
+For cloud-hosted canvas instances, the default value for the `JWK_BASE_URL` environmental variable will work out of the box. If you are not cloud-hosted, you may need to change the value of this variable in `.env.local` to match your canvas instance.
 
 ---
 ## Install the App
@@ -149,8 +149,10 @@ UDOIT now needs to be added to an account in Canvas. Follow these steps to add t
 4. Choose the `Apps` tab.
 5. Choose the `View App Configurations` button in the top right corner.
 6. Click `+ App`
-7. In the dialog that appears, choose "Configuration Type" "By Client ID".
+7. In the dialog that appears, choose "Configuration Type: By Client ID".
 8. Paste the `Client ID` from the developer LTI Key you created earlier.
 9. Click Submit.
 
-You're done!  "UDOIT" should now appear in the navigation menu of the course (or every course in the account) in which you installed it.  If you installed it to an account, "UDOIT Admin" will also appear in the account navigation menu.
+You're done!  "UDOIT" should now appear in the navigation menu of the course (or every course in the account) in which you installed it.  If you installed it on an account, "UDOIT Admin" will also appear in the account navigation menu.
+
+


### PR DESCRIPTION
The focus of these improvements are:
- Reduce verbosity
- Consistent formatting (e.g. steps are always in numbers)
- Improve clarity (e.g. always start instruction steps with 'what' before 'why')
- Add supporting links and missing instructions (e.g. migration warning)