### PR TITLE
makefile and compose improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log
 .phpunit.result.cache
 ###< phpunit/phpunit ###
 
-.env
+*.env

--- a/.ins.env.example
+++ b/.ins.env.example
@@ -1,0 +1,10 @@
+TITLE=Your institution name
+LMS_DOMAIN=myschool.instructure.com
+LMS_ID=canvas
+LMS_ACCOUNT_ID=1234567
+CREATED=2021-06-08
+STATUS=1
+VANITY_URL=canvas.myschool.edu
+METADATA={\"lang\":\"es\"}
+API_CLIENT_ID=1234500000000001234
+API_CLIENT_SECRET=your_api_client_secret

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,26 @@ ifneq (,$(wildcard ./.ins.env))
     export
 endif
 
+# spin up the containers
 start:
 	docker compose -f docker-compose.nginx.yml up -d
 
+# set up the database
 migrate:
 	docker compose -f docker-compose.nginx.yml run php php bin/console doctrine:migrations:migrate
 
-down:
+# stop the containers
+stop:
 	docker compose -f docker-compose.nginx.yml down
 
+# clear the Symfony cache
+clean-cache:
+	docker compose -f docker-compose.nginx.yml run php bin/console cache:clear
+
+# fill your institutions table data with the variables in your ins.env file. Use this command if you are using mysql.
 ins-mysql:
 	docker exec -it udoit3-db mysql -u root -proot udoit3 -e "INSERT INTO institution (title, lms_domain, lms_id, lms_account_id, created, status, vanity_url, metadata, api_client_id, api_client_secret) VALUES ('$(TITLE)', '$(LMS_DOMAIN)', '$(LMS_ID)', '$(LMS_ACCOUNT_ID)', '$(CREATED)', '$(STATUS)', '$(VANITY_URL)', '$(METADATA)', '$(API_CLIENT_ID)', '$(API_CLIENT_SECRET)');"
 
+# fill your institutions table data with the variables in your institutions.env file. Use this command if you are using postgresql.
 ins-psql:
 	docker exec -it -e PGPASSWORD=root udoit3-db psql -U root -d udoit3 -w -c "INSERT INTO institution (title, lms_domain, lms_id, lms_account_id, created, status, vanity_url, metadata, api_client_id, api_client_secret) VALUES ('$(TITLE)', '$(LMS_DOMAIN)', '$(LMS_ID)', '$(LMS_ACCOUNT_ID)', '$(CREATED)', '$(STATUS)', '$(VANITY_URL)', '$(API_CLIENT_ID)', '$(API_CLIENT_SECRET)');"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# checks if .ins.env exists and includes it
 ifneq (,$(wildcard ./.ins.env))
     include .ins.env
     export

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ifneq (,$(wildcard ./.ins.env))
+    include .ins.env
+    export
+endif
+
+start:
+	docker compose -f docker-compose.nginx.yml up -d
+
+migrate:
+	docker compose -f docker-compose.nginx.yml run php php bin/console doctrine:migrations:migrate
+
+down:
+	docker compose -f docker-compose.nginx.yml down
+
+ins-mysql:
+	docker exec -it udoit3-db mysql -u root -proot udoit3 -e "INSERT INTO institution (title, lms_domain, lms_id, lms_account_id, created, status, vanity_url, metadata, api_client_id, api_client_secret) VALUES ('$(TITLE)', '$(LMS_DOMAIN)', '$(LMS_ID)', '$(LMS_ACCOUNT_ID)', '$(CREATED)', '$(STATUS)', '$(VANITY_URL)', '$(METADATA)', '$(API_CLIENT_ID)', '$(API_CLIENT_SECRET)');"
+
+ins-psql:
+	docker exec -it -e PGPASSWORD=root udoit3-db psql -U root -d udoit3 -w -c "INSERT INTO institution (title, lms_domain, lms_id, lms_account_id, created, status, vanity_url, metadata, api_client_id, api_client_secret) VALUES ('$(TITLE)', '$(LMS_DOMAIN)', '$(LMS_ID)', '$(LMS_ACCOUNT_ID)', '$(CREATED)', '$(STATUS)', '$(VANITY_URL)', '$(API_CLIENT_ID)', '$(API_CLIENT_SECRET)');"

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,7 +1,6 @@
-version: "3.9"
-
 services:
   db:
+    container_name: udoit3-db
     image: mysql:latest
     volumes:
       - dbdata:/var/lib/mysql
@@ -15,6 +14,7 @@ services:
   # Uncomment this block and comment the next db block
   # to use Postgres instead of MySQL
   # db:
+  #   container_name: udoit3-db
   #   image: postgres:alpine
   #   restart: always
   #   ports:
@@ -24,6 +24,7 @@ services:
   #     POSTGRES_PASSWORD: udoit
   #     POSTGRES_DB: udoit3
   web:
+      container_name: udoit3-web
       image: nginx:latest
       ports:
         - "8000:80"
@@ -35,6 +36,7 @@ services:
       env_file:
         - .env
   php:
+      container_name: udoit3-php
       build:
         context: ./build/nginx
         dockerfile: Dockerfile.php.pdo.mysql
@@ -46,6 +48,7 @@ services:
       env_file:
         - .env
   composer:
+      container_name: udoit3-composer
       build:
         context: ./build/nginx
         dockerfile: Dockerfile.composer
@@ -55,6 +58,7 @@ services:
       env_file:
         - .env
   yarn:
+      container_name: udoit3-yarn
       image: node:16
       volumes:
         - ./:/app


### PR DESCRIPTION
## Changes
- container names are specified, ensuring no duplicate containers run under different directory names.
- all set up commands can be accessed through make commands
- database set up is a single make command instead of needing to work with the database manually

closes #948 