### PR TITLE
Changed redirect uri path to fix LTI key's common issue

### DIFF
--- a/src/Controller/LtiController.php
+++ b/src/Controller/LtiController.php
@@ -193,7 +193,7 @@ class LtiController extends AbstractController
             "public_jwk" => [],
             "description" => "User settings for UDOIT 3.x",
             "public_jwk_url" => "https://canvas.instructure.com/api/lti/security/jwks",
-            "target_link_uri" => "{$baseUrl}/dashboard",
+            "target_link_uri" => "{$baseUrl}/lti/authorize/check",
             "oidc_initiation_url" => "{$baseUrl}/lti/authorize"
         ];
 


### PR DESCRIPTION
Minor change to codebase with the hope of tackling the issue where users get a 500 error while loading UDOIT, due to the fact that the LTI key changes to a default (and incorrect) value. Thank you, @dgwn for finding the error!

Fixes #962 .