### PR TITLE
Show instructors in Admin Reports and populate user full names in DB

### DIFF
--- a/INSTALL_CANVAS.md
+++ b/INSTALL_CANVAS.md
@@ -46,6 +46,7 @@ We strongly recommend you enforce scopes with your API key. The following scopes
   * url:PUT|/api/v1/courses/:id
   * url:GET|/api/v1/courses/:id
   * url:POST|/api/v1/courses/:course_id/files
+  * url:GET|/api/v1/courses/:course_id/users
 * discussion_topics
   * url:GET|/api/v1/courses/:course_id/discussion_topics
   * url:PUT|/api/v1/courses/:course_id/discussion_topics/:topic_id
@@ -78,6 +79,10 @@ We strongly recommend you enforce scopes with your API key. The following scopes
   * url:GET|/api/v1/courses/:course_id/pages
   * url:GET|/api/v1/courses/:course_id/pages/:url_or_id
   * url:PUT|/api/v1/courses/:course_id/pages/:url_or_id
+ 
+* enrollments_api
+  * url:GET|/api/v1/courses/:course_id/enrollments
+  *   
 
 ---
 ## Create an LTI Developer Key

--- a/assets/js/Components/Admin/CoursesPage.js
+++ b/assets/js/Components/Admin/CoursesPage.js
@@ -24,7 +24,8 @@ export default function CoursePage({
   })
   
   const headers = [
-    { id: "courseName", text: t('report.header.course_name') }, 
+    { id: "courseName", text: t('report.header.course_name') },
+    { id: "instructors", text: "Instructors"}, 
     { id: "accountName", text: t('report.header.account_name') }, 
     { id: "lastUpdated", text: t('report.header.last_scanned') },
     { id: "errors", text: t('report.header.issues'), alignText: "center" }, 
@@ -61,10 +62,13 @@ export default function CoursePage({
       if (!excludeCourse) {
         // The Course data from the database is stored in the `course` object.
         // The data for the table is converted to the `row` object.
+        const names = Array.isArray(course.instructors) ? course.instructors : []
+
         let row = {
           id: course.id,
           course,
           courseName: <a href={course.publicUrl} target="_blank" rel="noopener noreferrer">{course.title}</a>,
+          instructors: names.length ? names.join(', ') : '-',
           courseTitle: course.title, // Used for sorting, not displayed outside of courseName element
           accountName: course.accountName,
           lastUpdated: course.lastUpdated,

--- a/assets/js/Components/Admin/ReportsPage.js
+++ b/assets/js/Components/Admin/ReportsPage.js
@@ -16,6 +16,7 @@ export default function ReportsPage({
 
   const [reports, setReports] = useState(null)
   const [issues, setIssues] = useState(null)
+  const [instructors, setInstructors] = useState([])
 
   const getReportHistory = () => {
     const api = new Api(settings)
@@ -34,6 +35,7 @@ export default function ReportsPage({
           else {
             setReports(null)
             setIssues(null)
+            setInstructors([]) 
           }
           
         })
@@ -49,10 +51,12 @@ export default function ReportsPage({
             }
             setReports(tempReports)
             setIssues(response.data.issues)
+            setInstructors(response.data.instructors || [])
           }
           else {
             setReports(null)
             setIssues(null)
+            setInstructors([])
           }
         })
     }
@@ -70,6 +74,15 @@ export default function ReportsPage({
       <div className="flex-row justify-content-center mt-3">
         <h1 className="mt-0 mb-0 primary-dark">{selectedCourse?.title || t('report.header.all_courses')}</h1>
       </div>
+
+      {selectedCourse && (instructors?.length ?? 0) > 0 && (
+        <div className="flex-row justify-content-center">
+          <div className="mt-1 secondary-dark">
+            {instructors.join(', ')}
+          </div>
+        </div>
+      )}
+
       { (reports === null) ? (
         <div className="mt-3 mb-3 flex-row justify-content-center">
           <div className="flex-column justify-content-center me-3">

--- a/src/Controller/LtiController.php
+++ b/src/Controller/LtiController.php
@@ -187,7 +187,7 @@ class LtiController extends AbstractController
                             ]
                         ]
                     ],
-                    "privacy_level" => "anonymous",
+                    "privacy_level" => "name_only",
                 ]
             ],
             "public_jwk" => [],

--- a/src/DoctrineMigrations/Version20250903152420.php
+++ b/src/DoctrineMigrations/Version20250903152420.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250903152420 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE course_user (id INT AUTO_INCREMENT NOT NULL, course_id INT NOT NULL, user_id INT DEFAULT NULL, lms_user_id VARCHAR(64) NOT NULL, display_name VARCHAR(255) DEFAULT NULL, fetched_at DATETIME DEFAULT NULL, INDEX IDX_45310B4F591CC992 (course_id), INDEX IDX_45310B4FA76ED395 (user_id), UNIQUE INDEX uniq_course_lmsuser (course_id, lms_user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE course_user ADD CONSTRAINT FK_45310B4F591CC992 FOREIGN KEY (course_id) REFERENCES course (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE course_user ADD CONSTRAINT FK_45310B4FA76ED395 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE users RENAME INDEX uniq_8d93d649f85e0677 TO UNIQ_1483A5E9F85E0677');
+        $this->addSql('ALTER TABLE users RENAME INDEX idx_8d93d64910405986 TO IDX_1483A5E910405986');
+        $this->addSql('ALTER TABLE messenger_messages CHANGE created_at created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE available_at available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE delivered_at delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE course_user DROP FOREIGN KEY FK_45310B4F591CC992');
+        $this->addSql('ALTER TABLE course_user DROP FOREIGN KEY FK_45310B4FA76ED395');
+        $this->addSql('DROP TABLE course_user');
+        $this->addSql('ALTER TABLE messenger_messages CHANGE created_at created_at DATETIME NOT NULL, CHANGE available_at available_at DATETIME NOT NULL, CHANGE delivered_at delivered_at DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE users RENAME INDEX idx_1483a5e910405986 TO IDX_8D93D64910405986');
+        $this->addSql('ALTER TABLE users RENAME INDEX uniq_1483a5e9f85e0677 TO UNIQ_8D93D649F85E0677');
+    }
+}

--- a/src/Entity/CourseUser.php
+++ b/src/Entity/CourseUser.php
@@ -1,0 +1,101 @@
+<?php
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Repository\CourseUserRepository::class)]
+#[ORM\Table(name: 'course_user')]
+#[ORM\UniqueConstraint(name: 'uniq_course_lmsuser', columns: ['course_id','lms_user_id'])]
+class CourseUser implements \JsonSerializable {
+  #[ORM\Id, ORM\GeneratedValue, ORM\Column(type:'integer')]
+  private ?int $id = null;
+
+  #[ORM\ManyToOne(targetEntity: Course::class)]
+  #[ORM\JoinColumn(nullable:false, onDelete:'CASCADE')]
+  private Course $course;
+
+  #[ORM\ManyToOne(targetEntity: User::class)]
+  #[ORM\JoinColumn(nullable:true, onDelete:'SET NULL')]
+  private ?User $user = null;
+
+  #[ORM\Column(name:'lms_user_id', type:'string', length:64)]
+  private string $lmsUserId;
+
+  #[ORM\Column(name:'display_name', type:'string', length:255, nullable:true)]
+  private ?string $displayName = null;
+
+  #[ORM\Column(name:'fetched_at', type:'datetime', nullable:true)]
+  private ?\DateTimeInterface $fetchedAt = null;
+
+public function jsonSerialize(): mixed
+    {
+        return [
+            'id'          => $this->getId(),
+            'courseId'    => $this->getCourse()->getId(),
+            'lmsUserId'   => $this->getLmsUserId(),
+            'displayName' => $this->getDisplayName(),
+            'fetchedAt'   => $this->getFetchedAt()?->format(DATE_ATOM),
+        ];
+    }
+
+  public function getId(): ?int
+{
+    return $this->id;
+}
+
+public function getCourse(): Course
+{
+    return $this->course;
+}
+
+public function setCourse(Course $course): self
+{
+    $this->course = $course;
+    return $this;
+}
+
+public function getUser(): ?User
+{
+    return $this->user;
+}
+
+public function setUser(?User $user): self
+{
+    $this->user = $user;
+    return $this;
+}
+
+public function getLmsUserId(): string
+{
+    return $this->lmsUserId;
+}
+
+public function setLmsUserId(string $lmsUserId): self
+{
+    $this->lmsUserId = $lmsUserId;
+    return $this;
+}
+
+public function getDisplayName(): ?string
+{
+    return $this->displayName;
+}
+
+public function setDisplayName(?string $displayName): self
+{
+    $this->displayName = $displayName;
+    return $this;
+}
+
+public function getFetchedAt(): ?\DateTimeInterface
+{
+    return $this->fetchedAt;
+}
+
+public function setFetchedAt(?\DateTimeInterface $fetchedAt): self
+{
+    $this->fetchedAt = $fetchedAt;
+    return $this;
+}
+
+}

--- a/src/Repository/CourseUserRepository.php
+++ b/src/Repository/CourseUserRepository.php
@@ -1,0 +1,75 @@
+<?php
+namespace App\Repository;
+
+use App\Entity\Course;
+use App\Entity\CourseUser;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class CourseUserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CourseUser::class);
+    }
+
+    /** Read all rows for a course (DB is the cache) */
+    public function findByCourse(Course $course): array
+    {
+            return $this->findBy(
+            ['course' => $course],
+            ['displayName' => 'ASC']
+        );
+    }
+
+    /** For TTL check: when did we last fetch any row for this course? */
+    public function maxFetchedAt(Course $course): ?\DateTimeInterface
+    {
+        $val = $this->createQueryBuilder('cu')
+            ->select('MAX(cu.fetchedAt)')
+            ->andWhere('cu.course = :course')
+            ->setParameter('course', $course)
+            ->getQuery()->getSingleScalarResult();
+
+        return $val ? new \DateTimeImmutable($val) : null;
+    }
+
+    /** Find the unique mapping row */
+    public function findOneByCourseAndLmsUserId(Course $course, string $lmsUserId): ?CourseUser
+    {
+        return $this->findOneBy(['course' => $course, 'lmsUserId' => $lmsUserId]);
+    }
+
+    /**
+     * Idempotent insert-or-update from API data.
+     * - Ensures one row per (course, lms_user_id)
+     * - Updates display_name if missing
+     * - Stamps fetched_at
+     * - Optionally links a User (when you have it)
+     */
+    public function upsertFromApi(Course $course, string $lmsUserId, ?string $displayName, ?User $user = null): CourseUser
+    {
+        $em = $this->getEntityManager();
+
+        $cu = $this->findOneByCourseAndLmsUserId($course, $lmsUserId);
+        if (!$cu) {
+            $cu = new CourseUser();
+            $cu->setCourse($course);
+            $cu->setLmsUserId($lmsUserId);
+            $em->persist($cu);
+        }
+
+        if ($displayName && !$cu->getDisplayName()) {
+            $cu->setDisplayName($displayName);
+        }
+
+        if ($user && !$cu->getUser()) {
+            $cu->setUser($user);
+        }
+
+        $cu->setFetchedAt(new \DateTimeImmutable());
+        // Do not flush here if you’ll call this in a loop; let the caller flush once.
+        return $cu;
+    }
+}

--- a/src/Services/LmsApiService.php
+++ b/src/Services/LmsApiService.php
@@ -91,4 +91,13 @@ class LmsApiService {
         return count($courses);
     }
 
+    public function getCourseTeachers(User $actingUser, int|string $lmsCourseId): array
+    {
+        $lms = $this->getLms($actingUser);
+        if (!\method_exists($lms, 'getCourseTeachers')) {
+            throw new \RuntimeException('getCourseTeachers not implemented for this LMS');
+        }
+        return $lms->getCourseTeachers($actingUser, $lmsCourseId);
+    }
+
 }


### PR DESCRIPTION
# Summary

### Users

- Full names are now stored at creation (`User.name` is populated; no more nulls).

### Admin Reports

- **Courses Page**: Added an **Instructors** column in the table.
- **Single Course Report**: Instructor list displayed under the course title (renders only when present).
- **Refresh Logic**: Instructor list refreshes from the LMS when stale (TTL = 24h).

---

# Key Changes

## Configuration

- LTI tool config updated to provide the user’s display name (`privacy_level = name_only`).
- Existing session → DB logic now ensures `User.name` is set during user creation.

## Backend

- Introduced **`course_user`** join table (`Course` ↔ `User` mapping) to cache instructors:
    - **Columns**: `course_id` (FK), `user_id` (nullable FK), `lms_user_id`, `display_name`, `fetched_at`.
    - **Constraints/Indexes**: Unique (`course_id`, `lms_user_id`); indexed on `course_id`, `user_id`.
- LMS integration fetches active teacher enrollments (fallback: users) and upserts into `course_user`.
- API now returns `instructors: string[]` for:
    - `GET /api/admin/courses/account/{account}/term/{term}`
    - `GET /api/admin/courses/{course}/reports/full`
- Cache invalidation: refresh from LMS if empty or older than 24h.

## Frontend

- **CoursesPage**: Added **Instructors** header/column with comma-separated names.
- **ReportsPage (single course)**: Render instructor list under the title; hidden when empty.