### PR TITLE
SensoryMisuse bug Fix

### DIFF
--- a/assets/js/Services/Html.js
+++ b/assets/js/Services/Html.js
@@ -429,13 +429,6 @@ export const findXpathFromElement = (element) => {
 
 export const findElementWithXpath = (content, xpath) => {
   
-  if(xpath.startsWith('/html[1]/body[1]/main[1]/')) {
-    xpath = xpath.replace('/html[1]/body[1]/main[1]/', '/html[1]/body[1]/')
-  }
-  else if (xpath.startsWith('/html[1]/body[1]/div[1]/')) {
-    xpath = xpath.replace('/html[1]/body[1]/div[1]/', '/html[1]/body[1]/')
-  }
-
   if(xpath.startsWith('/')) {
     xpath = xpath.substring(1)
   }


### PR DESCRIPTION
There were instances where the `SensoryMisuse` issue was finding text with no sensory words. Issue was much different where it was finding it but the error element pointed to by the xpath was different. Turns out our equal access scanner was not saving xpath with a `main`. 

Fix:
Don't check for `main` or `div[1]` in `html.js`