### PR TITLE
Aria-Complementary-Label-Visible Form - Final

### DIFF
--- a/assets/js/Components/FixIssuesPage.js
+++ b/assets/js/Components/FixIssuesPage.js
@@ -118,6 +118,11 @@ export default function FixIssuesPage({
   const [widgetState, setWidgetState] = useState(WIDGET_STATE.LOADING)
   const [liveUpdateToggle, setLiveUpdateToggle] = useState(true)
 
+  const [previewInfo, setPreviewInfo] = useState({
+     aria_complementary_id: ""
+  })
+  const [copiedContentItem, setCopiedContentItem] = useState(""); // This is the temporary content item used to manipulate the activeContentItem for when we need to manipulate actual DOM
+
   // The database stores and returns certain issue data, but it needs additional attributes in order to
   // be really responsive on the front end. This function adds those attributes and stores the database
   // information in the "issue" attribute.
@@ -676,13 +681,13 @@ export default function FixIssuesPage({
   }
 
   const getNewFullPageHtml = (content, issue) => {
-    if(!content?.body || !issue) {
+    if(!content || !issue) {
       return
     }
 
     // Create the full HTML string for the new version of the content item.
     const parser = new DOMParser()
-    const tempDoc = parser.parseFromString(content.body, 'text/html')
+    const tempDoc = parser.parseFromString(content, 'text/html')
 
     let errorElement = Html.findElementWithIssue(tempDoc, issue)
       
@@ -730,7 +735,16 @@ export default function FixIssuesPage({
       }
     }
 
-    let fullPageHtml = getNewFullPageHtml(activeContentItem, issue)
+    let currentContent;
+    if(copiedContentItem){ // In the case we ARE using copiedContentItem during save we MUST change the active content item 
+     currentContent = copiedContentItem
+    }
+    else{
+      currentContent = activeContentItem.body
+    }
+
+
+    let fullPageHtml = getNewFullPageHtml(currentContent, issue)
     let fullPageDoc = new DOMParser().parseFromString(fullPageHtml, 'text/html')
     let newElement = Html.findElementWithError(fullPageDoc, issue?.newHtml)
     let newXpath = Html.findXpathFromElement(newElement)
@@ -992,6 +1006,7 @@ export default function FixIssuesPage({
                   severity={tempActiveIssue.severity}
                   tempActiveIssue={tempActiveIssue}
                   triggerLiveUpdate={triggerLiveUpdate}
+                  previewInfo={previewInfo}
                 />
             ) : ''}
           </section>
@@ -1006,6 +1021,10 @@ export default function FixIssuesPage({
                 contentItemsBeingScanned={contentItemsBeingScanned}
                 liveUpdateToggle={liveUpdateToggle}
                 setIsErrorFoundInContent={setIsErrorFoundInContent}
+                previewInfo={previewInfo}
+                setPreviewInfo={setPreviewInfo}
+                copiedContentItem={copiedContentItem}
+                setCopiedContentItem={setCopiedContentItem}
               />
             )}
             <div className="flex-row justify-content-end gap-2 mt-3">

--- a/assets/js/Components/Forms/AriaLabelVisible.js
+++ b/assets/js/Components/Forms/AriaLabelVisible.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react'
+import * as Html from '../../Services/Html'
+import FormSaveOrReview from './FormSaveOrReview'
+
+
+const AriaLabelVisible = ({
+  t,
+  settings,
+  activeIssue,
+  handleIssueSave,
+  isDisabled,
+  handleActiveIssue,
+  markAsReviewed,
+  setMarkAsReviewed,
+  previewInfo
+}) => {
+
+  const [inputErrors, setInputErrors] = useState([])
+
+  useEffect(() => {
+      if(!activeIssue){
+          return
+        }
+      setInputErrors([])
+
+    }, [activeIssue])
+
+    useEffect(() => {
+      updateActiveHtml()
+      checkFormErrors()
+    }, [previewInfo])
+
+    const updateActiveHtml = () => {      
+      const html = Html.getIssueHtml(activeIssue)
+      let element = Html.toElement(html)
+  
+      element = Html.removeAttribute(element, 'aria-label')
+      element = Html.setAttribute(element, 'aria-labelledby', previewInfo.aria_complementary_id); 
+      
+      let issue = activeIssue
+      issue.newHtml = Html.toString(element)
+
+      handleActiveIssue(issue)
+      
+    }
+
+    const checkFormErrors = () => {
+      let tempErrors = []
+      if(!previewInfo.aria_complementary_id){
+        tempErrors.push({text: "No ID", type: "error"})
+      }
+
+      setInputErrors(tempErrors)
+    }
+
+    const handleSubmit = () => {
+       if(inputErrors.length == 0){
+          handleIssueSave(activeIssue)
+       }
+    }
+
+  return (
+    <FormSaveOrReview 
+        t={t}
+            settings={settings}
+            activeIssue={activeIssue}
+            isDisabled={isDisabled}
+            handleSubmit={handleSubmit}
+            formErrors={inputErrors}
+            markAsReviewed={markAsReviewed}
+            setMarkAsReviewed={setMarkAsReviewed}
+        />
+  )
+}
+
+export default AriaLabelVisible

--- a/assets/js/Components/Widgets/FixIssuesContentPreview.css
+++ b/assets/js/Components/Widgets/FixIssuesContentPreview.css
@@ -229,3 +229,12 @@
     border: 1px solid var(--white)
   }
 }
+
+.ufixit-content-preview-main.ufixit-clickable-container *{
+  cursor: pointer;
+}
+
+.ufixit-content-preview-main.ufixit-clickable-container *.selected{
+  cursor: pointer;
+  border: 2px solid blue;
+}

--- a/assets/js/Components/Widgets/FixIssuesContentPreview.js
+++ b/assets/js/Components/Widgets/FixIssuesContentPreview.js
@@ -18,6 +18,10 @@ export default function FixIssuesContentPreview({
   contentItemsBeingScanned,
   liveUpdateToggle,
   setIsErrorFoundInContent,
+  previewInfo,
+  setPreviewInfo,
+  copiedContentItem,
+  setCopiedContentItem
 }) {
 
   const [taggedContent, setTaggedContent] = useState(null)
@@ -26,6 +30,16 @@ export default function FixIssuesContentPreview({
 
   const [isInitialLoad, setIsInitialLoad] = useState(false)
   const [debouncedDirection, setDebouncedDirection] = useState(null)
+
+   // Default/Reset values for the previewInfoState
+  const DEFAULT_PREVIEW_VALUES = {
+    aria_complementary_id: ""
+  }
+
+  // On First load we reset the values so we don't load in borders
+  useEffect(() => {
+    setPreviewInfo(DEFAULT_PREVIEW_VALUES)
+  }, [])
 
   const checkScrollButton = () => {
     if(isInitialLoad) {
@@ -61,12 +75,17 @@ export default function FixIssuesContentPreview({
   }
 
   const ALT_TEXT_RELATED = [
-    formNames.ALT_TEXT,            
+    formNames.ALT_TEXT,
+    formNames.ARIA_LABEL_VISIBLE,            
     formNames.ANCHOR_TEXT,
     formNames.BLOCKQUOTE,
     formNames.EMBEDDED_CONTENT_TITLE,
     formNames.LABEL,
     formNames.LABEL_UNIQUE
+  ]
+
+  const CLICKABLE_PREVIEW = [
+    formNames.ARIA_LABEL_VISIBLE
   ]
 
   const HEADINGS_RELATED = [
@@ -88,6 +107,115 @@ export default function FixIssuesContentPreview({
     return htmlElement
   }
 
+  // Finds an element using a xpath in a htmlString --> inser an ID onto that element --> Make the new tagged and copied content into that new strigified DOM
+function addIdToElementInHtml(htmlString, xpath, generatedId) {
+    const parser = new DOMParser()
+    const document = parser.parseFromString(htmlString, 'text/html')
+
+    const element_from_xpath = Html.findElementWithXpath(document, xpath)
+    element_from_xpath.setAttribute('id', generatedId)
+
+    const stringified_content = Html.toString(document.body)
+
+    setTaggedContent(stringified_content) // What renders changes onto our page
+    setCopiedContentItem(stringified_content) // We will use this during save
+
+}
+
+function removeIdToElementInHtml(htmlString, xpath, id){
+    const parser = new DOMParser()
+    const document = parser.parseFromString(htmlString, 'text/html')
+
+    const element_from_xpath = Html.findElementWithXpath(document, xpath)
+    element_from_xpath.removeAttribute('id')
+
+    const stringified_content = Html.toString(document.body)
+
+    setTaggedContent(stringified_content) // What renders changes onto our page
+    setCopiedContentItem(stringified_content) // We will use this during save
+}
+
+// Different forms handle preview values differently, preview value is set in accordance of form 
+  const handlePreviewValues = (newId, selectedFlag = false) => { // selectedFlag indicates how we need to deal elements already selected, be default false
+    const currentForm = formNameFromRule(activeIssue.scanRuleId)
+
+    if(currentForm == formNames.ARIA_LABEL_VISIBLE){
+      // Reset value/Deselection
+      if(selectedFlag){
+        setPreviewInfo(prevInfo => ({
+          ...prevInfo,
+          aria_complementary_id: DEFAULT_PREVIEW_VALUES.aria_complementary_id
+        }))
+        return
+      }
+
+      // Seleting value
+      setPreviewInfo(prevInfo => ({
+          ...prevInfo,
+          aria_complementary_id: newId
+        }))
+        return
+    }
+
+
+  }
+
+  const handleClickablePreview = (e) => {
+    //  We are on a Form where we don't just want the user to click around
+    if(!CLICKABLE_PREVIEW.includes(formNameFromRule(activeIssue.scanRuleId))){
+      console.log("Can't click around when not alowed!")
+      return
+    }
+
+    // We don't want the user to click on the active issue of a page
+    if(e.target.classList.contains('ufixit-error-highlight')){
+      console.log("Can't click on a active issue!")
+      return
+    }
+
+    // In the case the user clicks on the main div, we should reset everything 
+    if(e.target.classList.contains("ufixit-content-preview-main")){
+      setCopiedContentItem("")
+      setTaggedContent(getTaggedContent(activeIssue, activeContentItem))
+      setPreviewInfo(DEFAULT_PREVIEW_VALUES)
+      return      
+    }
+
+    // Selecting an already selected element --> Deselect and reset and accordingly 
+    if(e.target.classList.contains("selected")){
+      if(e.target.id && e.target.id.includes('-clickable-id')){
+        const elemetn_xpath = Html.findXpathFromElement(e.target, 'ufixit-content-preview-main') // Need xpath of element because react is stupid
+        removeIdToElementInHtml(taggedContent, elemetn_xpath, e.target.id)
+      }
+      handlePreviewValues(e.target.id, true)
+      return
+    }
+
+
+    let element_id = e.target.id // ID of the element we want to use for the element
+    // No ID case
+    if(!element_id || element_id == ""){
+      const generated_id = e.target.innerHTML.split(' ')[0] + "-clickable-id" // Generating new ID for us to use
+      const elemetn_xpath = Html.findXpathFromElement(e.target, 'ufixit-content-preview-main') // Need xpath of element because react is stupid
+      // Reset all content item to orginal before proceeding
+      if(copiedContentItem){
+        setCopiedContentItem("")
+        setTaggedContent(getTaggedContent(activeIssue, activeContentItem))
+      }
+      addIdToElementInHtml(taggedContent, elemetn_xpath, generated_id) // Add generated ID to tagged HTML
+      handlePreviewValues(generated_id) // Call Handler
+
+    }
+    else{
+      // In the case the user clicks an non-id element first AND then clicks on an ID'ed one, we want to ensure that the ID is deleted first
+      if(copiedContentItem && formNameFromRule(activeIssue.scanRuleId) == formNames.ARIA_LABEL_VISIBLE){ // Only the case for aria_complementary that we must reset like this
+        setCopiedContentItem("")
+        setTaggedContent(getTaggedContent(activeIssue, activeContentItem))
+      }
+      handlePreviewValues(element_id) // Call Handler 
+    }
+  }
+
   const addPreviewHelperElements = (doc, errorElement) => {
     if(!activeIssue || !doc || !errorElement) {
       return doc
@@ -95,7 +223,9 @@ export default function FixIssuesContentPreview({
 
     // If the issue edits the alt text, we need to show the auto-updating alt text preview
     if (ALT_TEXT_RELATED.includes(formNameFromRule(activeIssue.scanRuleId))) {
-      let altText = Html.getAccessibleName(errorElement)
+      const htmlElement = document.getElementsByClassName('ufixit-error-highlight')[0]
+      const allElements = Array.from(document.querySelectorAll('#ufixit-content-preview-main *')) // This gets all the elements from the current document under the big div
+      let altText = Html.getAccessibleName(htmlElement, allElements)
       
       // If there is alt text to show...
       if (altText && altText.trim() !== '') {
@@ -159,6 +289,27 @@ export default function FixIssuesContentPreview({
         headingElement.classList.add('ufixit-heading-highlight')
         headingElement.setAttribute('ufixit-heading-type', headingType)
       })
+    }
+
+    if(CLICKABLE_PREVIEW.includes(formNameFromRule(activeIssue.scanRuleId))){
+      const errorElement = document.getElementsByClassName('ufixit-error-highlight')[0]
+      const elements = Array.from(document.querySelectorAll('#ufixit-content-preview-main *'))
+      elements.forEach((element) => {
+        // Add a 'Click to Select this Element' to every element except for the current error element
+        if(element != errorElement){
+          element.setAttribute('title', `${t(`misc.clickable_elements`)}`)
+        }
+        // Selection logic by using class if something is selected
+        if(element.id && element.id == previewInfo.aria_complementary_id){
+          element.classList.add('selected')
+        }
+        else if(element.classList.contains('selected')){
+          element.classList.remove('selected')
+        }
+
+        
+      })
+
     }
 
     return doc
@@ -396,10 +547,12 @@ export default function FixIssuesContentPreview({
                     { canShowPreview ? (
                       <>
                         <div
-                          className="ufixit-content-preview-main"
+                          className={CLICKABLE_PREVIEW.includes(formNameFromRule(activeIssue.scanRuleId)) ? `ufixit-content-preview-main ufixit-clickable-container` : `ufixit-content-preview-main`}
+                          id='ufixit-content-preview-main'
                           onScroll={() => {
                             checkScrollButton()
                           }}
+                          onClick={handleClickablePreview}
                           dangerouslySetInnerHTML={{__html: taggedContent}} />
                         {!isIssueElementVisible && !isInitialLoad && debouncedDirection && (
                           <div className='scroll-to-error-container'>

--- a/assets/js/Components/Widgets/UfixitWidget.js
+++ b/assets/js/Components/Widgets/UfixitWidget.js
@@ -25,7 +25,8 @@ export default function UfixitWidget({
   setTempActiveIssue,
   severity,
   tempActiveIssue,
-  triggerLiveUpdate
+  triggerLiveUpdate,
+  previewInfo
 }) {
 
   const [UfixitForm, setUfixitForm] = useState(null)
@@ -199,7 +200,9 @@ export default function UfixitWidget({
                       isContentLoading={isContentLoading}
                       isDisabled={markAsReviewed || isContentLoading || !isErrorFoundInContent}
                       markAsReviewed={markAsReviewed}
-                      setMarkAsReviewed={setMarkAsReviewed} /> )
+                      setMarkAsReviewed={setMarkAsReviewed} 
+                      previewInfo={previewInfo}
+                      /> )
                   }
                 </div>
               </div>

--- a/assets/js/Services/Html.js
+++ b/assets/js/Services/Html.js
@@ -329,7 +329,7 @@ export function getIssueHtml(issue) {
   return issue.newHtml ? issue.newHtml : issue.sourceHtml
 }
 
-export function getAccessibleName(element) {
+export function getAccessibleName(element, allElements = null) {
   if ('string' === typeof element) {
     element = toElement(element)
   }
@@ -342,6 +342,17 @@ export function getAccessibleName(element) {
     https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#name_calculation  */
 
   // 1. TODO: If the element has the 'aria-labelledby' attribute, use the value of the corresponding element.
+  let ariaLabelledby = getAttribute(element, "aria-labelledby")
+  if(ariaLabelledby){
+    let corresponding_element = null
+    allElements.forEach((element) => {
+      if(element.id == ariaLabelledby){
+        corresponding_element = element
+      }
+    })
+
+    return corresponding_element ? corresponding_element.innerHTML : null
+  }
   
   // 2. If the element has the 'aria-label' attribute, use that value.
   let ariaLabel = getAttribute(element, 'aria-label')
@@ -409,7 +420,7 @@ export function getAccessibleName(element) {
   return ''
 }
 
-export const findXpathFromElement = (element) => {
+export const findXpathFromElement = (element, id=null) => {
   if (!element) {
     return null
   }
@@ -417,6 +428,9 @@ export const findXpathFromElement = (element) => {
   // Get the path to the element
   let path = []
   while (element && element.nodeType === Node.ELEMENT_NODE) {
+    if(element.id && element.id == id){
+      break
+    }
     let tagName = element.tagName.toLowerCase()
     let siblings = Array.from(element.parentNode.children).filter(sibling => sibling.tagName.toLowerCase() === tagName)
     let index = siblings.indexOf(element) + 1 // +1 for 1-based index

--- a/assets/js/Services/Ufixit.js
+++ b/assets/js/Services/Ufixit.js
@@ -1,5 +1,6 @@
 import AltText from '../Components/Forms/AltText'
 import AnchorText from '../Components/Forms/AnchorText'
+import AriaLabelVisible from '../Components/Forms/AriaLabelVisible'
 import AriaRoleForm from '../Components/Forms/AriaRoleForm'
 import BlockquoteForm from '../Components/Forms/BlockquoteForm'
 import ContrastForm from '../Components/Forms/ContrastForm'
@@ -21,6 +22,7 @@ import UfixitReviewOnly from '../Components/Forms/UfixitReviewOnly'
 export const formNames = {
   ALT_TEXT: 'alt_text',
   ANCHOR_TEXT: 'anchor_text',
+  ARIA_LABEL_VISIBLE: 'aria_label_visible',
   ARIA_ROLE: 'aria_role',
   BLOCKQUOTE: 'blockquote',
   CONTRAST: 'contrast',
@@ -51,6 +53,7 @@ export const disabilityTypes = {
 const formTypes = {
   [formNames.ALT_TEXT]: AltText,
   [formNames.ANCHOR_TEXT]: AnchorText,
+  [formNames.ARIA_LABEL_VISIBLE]: AriaLabelVisible,
   [formNames.ARIA_ROLE]: AriaRoleForm,
   [formNames.BLOCKQUOTE]: BlockquoteForm,
   [formNames.CONTRAST]: ContrastForm,
@@ -105,6 +108,8 @@ const rulesToFormNameMap = {
 
   a_text_purpose: formNames.ANCHOR_TEXT,
   area_alt_exists: formNames.ANCHOR_TEXT,
+
+  aria_complementary_label_visible: formNames.ARIA_LABEL_VISIBLE,
 
   aria_role_valid: formNames.ARIA_ROLE,
   aria_role_allowed: formNames.ARIA_ROLE,


### PR DESCRIPTION
## Summary

This PR adds a new form for dealing with the issue ruleset: aria_complementary_label_visible which requires clickable elements. This allows for the preview on the right of the form to be now interactable.

## Key Changes
A new state variable `previewInfo` is being passed by the parent component `FixIssuesPage.js` to `FixIssuesContentPreview.js` and `UfixitWidget.js` which allows it to be used by the preview element + the form. This is the main input for this form and form is checked for errors and saved using this variable

A new state variable `copiedContentItem` is being passed down from the parent component `FixIssuesPage.js` to `FixIssuesContentPreview.js` where it is being used to keep track of newly added IDs to elements that are NOT the `activeIssue` element. The `handleIssueSave()` function now checks this variable and priortizes the html stored in it before saving.

Also check the following functions in `FixIssuesContentPreview.js` for in-depth understanding of how the functionalities work:

- `addIdToElementInHtml(htmlString, xpath, generatedId)`
- `removeIdToElementInHtml(htmlString, xpath, id)`
-  `handlePreviewValues = (newId, selectedFlag = false)`
-  `handleClickablePreview = (e)` 



## Functionalities
When this form is now active we can click on any elements on the right EXCEPT the element pointed to by the `activeIssue`. 

The following behaviour is expected: 

- When clicking on an element with an already EXISTING ID, it is highlighted and the ID is saved in `previewInfo` for later saving
- When clicking on an element with a NON-EXISTING ID, it:

    - First Generates the ID
    - Attaches the ID to the element and updates the page
    - Save a copy of the updated html in `copiedContentItem` for later saving

- When clicking on an already selected element, it is deselected with all IDs reset to correct values
- When clicking on an already selected element with a custom generated ID, the ID is removed and then deselected
- Clicking anywhere else on the preview container deselects everything and resets everything


## Testing 
To test this form:

- Make a new canvas content item (page works best)
- Edit it's html
- Add all elements you need and add an an elements with a complementary role with an aria-label attribute OR an `aside` element with an aria-label attribute.

