### PR TITLE
Canvas API pull updated to get page body.

### DIFF
--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -198,7 +198,7 @@ class CanvasLms implements LmsInterface
         }
 
         /* get page content */
-        if ('page' === $contentType) {
+        if ('page' === $contentType && $lmsContent["body"] === '') {
             $url = "courses/{$course->getLmsCourseId()}/pages/{$lmsContent['id']}";
             $pageResponse = $canvasApi->apiGet($url);
             $pageObj = $pageResponse->getContent();
@@ -1074,7 +1074,7 @@ class CanvasLms implements LmsInterface
             'discussion_topic' =>   "courses/{$courseId}/discussion_topics",
             'file' =>               "courses/{$courseId}/files",
             'module' =>             "courses/{$courseId}/modules?include[]=items",
-            'page' =>               "courses/{$courseId}/pages",
+            'page' =>               "courses/{$courseId}/pages?include[]=body",
             'quiz' =>               "courses/{$courseId}/quizzes",
         ];
     }


### PR DESCRIPTION
Adds the `include[]=body` argument to the Pages API. Unlike other attempts to speed up the loading page's synching, this one doesn't hit the rate-limiting issues with the Canvas API or lead to other problems like threading issues and race conditions.

If all the pages HAVE bodies returned, it skips the loop to retrieve them  one-at-a-time from Canvas.

In local testing on the [Equal Access Test Course](https://ucf.test.instructure.com/courses/1486139), this improved the speed of the synching process by between 2-3x.

| Build | Sync Time (in seconds) | Average |
| --- | --- | --- |
| dev | 35.97, 27.78, 29.09, 26.36, 25.49 |  **28.94** |
| `include[]=body` | 9.87, 10.06, 8.93, 11.19, 10.80 |  **10.17** |

Thanks to @cj-young for finding this in his backend re-write work.